### PR TITLE
Fix one node install taint issue

### DIFF
--- a/scripts/cluster/create_one_node_cluster.sh
+++ b/scripts/cluster/create_one_node_cluster.sh
@@ -61,5 +61,6 @@ fi
 
 # Untaint master (allow pods to be scheduled on master) 
 kubectl taint nodes --all node-role.kubernetes.io/master-
+kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 
 $DIR/setup_master_node.sh $STOCK_CONTAINERD


### PR DESCRIPTION
It seems that the following taint is applied to the single node `node-role.kubernetes.io/control-plane`. It causes deployment suspension due to pod affinity.
### Image for reference
`kubectl get nodes`
![image](https://user-images.githubusercontent.com/51022808/193791469-2c5f7a3f-4a86-4c5d-9a94-736c4e9b3f09.png)
`kubectl describe node vhive-sched-bench | grep Taints`
![image](https://user-images.githubusercontent.com/51022808/193791519-e594d4a9-f8c9-4f02-a8b3-21a6d6c72339.png)
