### PR TITLE
When pulling images check for stale cached images

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -99,7 +99,8 @@ jobs:
       run: ./scripts/setup_tool setup_firecracker_containerd
 
     - name: Build
-      run: go build -race -v -a ./...
+      run: |
+        go build -race -v -a ./...
 
     - name: Run tests in submodules
       run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -78,7 +78,11 @@ jobs:
         sudo add-apt-repository ppa:git-core/ppa -y
         sudo apt update
         sudo apt install git -y
-        
+
+    - name: Check if skopeo is installed
+      run: |
+        skopeo --version
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -79,9 +79,13 @@ jobs:
         sudo apt update
         sudo apt install git -y
 
-    - name: Check if skopeo is installed
+    - name: Install skopeo
       run: |
+        echo "deb http://mirrors.kernel.org/ubuntu kinetic main universe" | sudo tee -a /etc/apt/sources.list
+        sudo apt update
+        sudo apt install skopeo -y
         skopeo --version
+        
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/ctriface/iface.go
+++ b/ctriface/iface.go
@@ -350,12 +350,12 @@ func imageIsOutdated(cachedImage containerd.Image, imageUrl string) bool {
 // By default, uses the authorization state in $XDG_RUNTIME_DIR/containers/auth.json,
 // which is set using skopeo login.
 func fetchLatestImageDigest(imageUrl string) (string, error) {
-	cmd := fmt.Sprintf("skopeo inspect docker://%s | jq -r '.Digest'", imageUrl)
+	cmd := fmt.Sprintf("skopeo inspect 'docker://%s' --tls-verify=false | jq -r '.Digest'", imageUrl)
 
 	start := time.Now()
 	out, err := exec.Command("bash", "-c", cmd).Output()
 	elapsed := time.Since(start)
-	log.Debugf("Latest image digest fetching took %s", elapsed)
+	log.Debugf("Fetched '%s' image digest in %v (error = %v)\n", imageUrl, elapsed, err)
 
 	return string(out), err
 }

--- a/ctriface/iface_test.go
+++ b/ctriface/iface_test.go
@@ -53,7 +53,7 @@ func TestPauseSnapResume(t *testing.T) {
 
 	log.SetOutput(os.Stdout)
 
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), namespaceName), testTimeout)
@@ -96,7 +96,7 @@ func TestStartStopSerial(t *testing.T) {
 
 	log.SetOutput(os.Stdout)
 
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), namespaceName), testTimeout)
@@ -130,7 +130,7 @@ func TestPauseResumeSerial(t *testing.T) {
 
 	log.SetOutput(os.Stdout)
 
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), namespaceName), testTimeout)
@@ -170,7 +170,7 @@ func TestStartStopParallel(t *testing.T) {
 
 	log.SetOutput(os.Stdout)
 
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 
 	testTimeout := 360 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), namespaceName), testTimeout)
@@ -229,7 +229,7 @@ func TestPauseResumeParallel(t *testing.T) {
 
 	log.SetOutput(os.Stdout)
 
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 
 	testTimeout := 120 * time.Second
 	ctx, cancel := context.WithTimeout(namespaces.WithNamespace(context.Background(), namespaceName), testTimeout)

--- a/ctriface/iface_test.go
+++ b/ctriface/iface_test.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2020 Dmitrii Ustiugov, Plamen Petrov and EASE lab
+// # Copyright (c) 2020 Dmitrii Ustiugov, Plamen Petrov and EASE lab
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -41,7 +41,7 @@ var (
 	isUPFEnabled = flag.Bool("upf", false, "Set UPF enabled")
 	isLazyMode   = flag.Bool("lazy", false, "Set lazy serving on or off")
 	//nolint:deadcode,unused,varcheck
-	isWithCache  = flag.Bool("withCache", false, "Do not drop the cache before measurements")
+	isWithCache = flag.Bool("withCache", false, "Do not drop the cache before measurements")
 )
 
 func TestPauseSnapResume(t *testing.T) {

--- a/scripts/self-hosted-kind/scripts/setup-runner.sh
+++ b/scripts/self-hosted-kind/scripts/setup-runner.sh
@@ -24,6 +24,9 @@
 
 set -e
 
+# Needed for 'skopeo'
+echo "deb http://mirrors.kernel.org/ubuntu kinetic main universe" | sudo tee -a /etc/apt/sources.list
+
 # Install base- and setup-dependencies
 apt-get update
 apt-get install --yes \

--- a/taps/tapManager.go
+++ b/taps/tapManager.go
@@ -126,7 +126,6 @@ func setupForwardRules(tapName, hostIface string) error {
 		}
 	}
 
-
 	conn := nftables.Conn{}
 
 	// 1. nft add table ip filter


### PR DESCRIPTION
## Summary

When vHive does pull images, it must check in its local cache if an image is stale. vHive should do this without pulling the whole image again. `skopeo` is used to only inspect the metadata from a remote image.
