### PR TITLE
Optimized dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,36 +5,33 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/function-images/tests/chained-function-serving"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/function-images/tests/chained-function-eventing"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "gomod"
-    directory: "/utils/benchmarking/eventing"
-    schedule:
-      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
 
   - package-ecosystem: "gomod"
     directory: "/utils/tracing/go"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
 
   - package-ecosystem: "gomod"
     directory: "/examples/deployer"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
 
   - package-ecosystem: "gomod"
     directory: "/examples/invoker"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
 
   # Enable version updates for Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Disabled tracking of some benchmarks (to be decomissioned in favor of vSwarm)
- Disable dependabot updates of patch versions 
