### PR TITLE
Update quick start and developer's guide

### DIFF
--- a/docs/developers_guide.md
+++ b/docs/developers_guide.md
@@ -19,6 +19,8 @@ watch kubectl get pods -A
 kn service apply
 ```
 
+To deploy a function in the stock or gVisor execution environment, please create and use your own YAML files following this [example](https://github.com/knative/docs/tree/main/code-samples/serving/hello-world/helloworld-python#yaml)
+
 ### Clean up
 ```bash
 ./scripts/github_runner/clean_cri_runner.sh stock-only

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -2,6 +2,8 @@
 This guide describes how to set up an _N_-node vHive serverless cluster with Firecracker MicroVMs.
 See [here][github-toc] to learn where to find table of contents.
 
+To see how to setup a single node cluster with stock-only or gVisor, see [Developer's guide](developers_guide.md).
+
 ## Table of Contents
 1. [Host platform requirements](#I-host-platform-requirements)
     1. [Hardware](#1-hardware)
@@ -259,6 +261,8 @@ for benchmarking asynchronous (i.e., Knative Eventing) case and more details abo
     > **BEWARE:**
     >
     > Deployer **cannot be used for Knative eventing** (i.e., asynchronous) workflows. You need to deploy them manually instead.
+    >
+    > Deployer uses YAML files defined in configs/knative-workload that are **specific** to firecracker. Please refer to the [Developer's Guide](developers_guide.md) for deploying functions in the container or gVisor based environment.
 
     > **Note:**
     >


### PR DESCRIPTION
Add link to developer's guide in quick start guide for setting up one node stock only environment.
Add how to deploy functions to stock only environment.