### PR TITLE
Updated the maintainers, email, tutorial, workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ and Containerd containers (as in vanilla Knative).
 ### Technical talks
 
 * [Slides](docs/talks/vHive_REAP_@AWS_04_02_2021.pdf) from
-[Dmitrii](http://homepages.inf.ed.ac.uk/s1373190/)'s talk at AWS on Feb, 4th 2021.
+[Dmitrii](https://ustiugov.github.io)'s talk at AWS on Feb, 4th 2021.
 * ASPLOS'21 talks on YouTube:
 [short](https://www.youtube.com/watch?v=w1vGb0X0SUQ), [long](https://www.youtube.com/watch?v=zfLd_MTGOA8).
+* Serverless and vHive tutorial [series](https://www.youtube.com/playlist?list=PLVdxPJaekjWqBsEUwnrYRQCaMqvcDVsBE)
+* Upcoming serverless computing workshop at EuroSys 2023 [website](https://vhive-serverless.github.io/sesame-eurosys23)
 
 
 ## Referencing our work
@@ -125,7 +127,6 @@ The software is maintained at the [EASE lab](https://easelab.inf.ed.ac.uk/) in t
 ### Maintainers
 
 * High-level architecture, issues and discussions on GitHub, roadmap: Dmitrii Ustiugov ([GitHub](https://github.com/ustiugov),
-[twitter](https://twitter.com/DmitriiUstiugov), [web page](http://homepages.inf.ed.ac.uk/s1373190/));
+[twitter](https://twitter.com/DmitriiUstiugov), [web page](https://ustiugov.github.io));
 * Integration with firecracker-containerd [Plamen Petrov](https://github.com/plamenmpetrov);
-* Integration with gVisor: [Nathaniel Tornow](https://github.com/nathanieltornow), [Alexandrina Panfil](https://github.com/alexandrinapanfil);
 * Integration with Knative: [Shyam Jesalpura](https://github.com/shyamjesal)

--- a/configs/.linkcheck.json
+++ b/configs/.linkcheck.json
@@ -1,8 +1,11 @@
 {
     "ignorePatterns": [
-		{
-			"pattern": "^http://localhost:*"
-		}
+        {
+            "pattern": "^http://localhost:*"
+        },
+        {
+            "pattern": "^https://opensource.org*"
+        }
     ],
     "replacementPatterns": [
         {

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ replace (
 )
 
 replace (
-	github.com/firecracker-microvm/firecracker-containerd => github.com/ease-lab/firecracker-containerd v0.0.0-20210618165033-6af02db30bc4
+	github.com/firecracker-microvm/firecracker-containerd => github.com/vhive-serverless/firecracker-containerd v0.0.0-20210618171548-4a8adae2660e
 	github.com/vhive-serverless/vhive/examples/protobuf/helloworld => ./examples/protobuf/helloworld
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1046,6 +1046,8 @@ github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk
 github.com/valyala/quicktemplate v1.1.1/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/vhive-serverless/firecracker-containerd v0.0.0-20210618171548-4a8adae2660e h1:6kcipLB/LX8J1XFw+vOipz0qwvDHiv5KoyQZgXRmySc=
+github.com/vhive-serverless/firecracker-containerd v0.0.0-20210618171548-4a8adae2660e/go.mod h1:Uon4eMMkFBsj2aYWnk1wz3xebaKgR3+CCjmc62cCcvo=
 github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=


### PR DESCRIPTION
## Summary

- Removed Nate from the list of maintainers, as per his request.
- Updated Dmitrii's email
- Added links to the past tutorial at ASPLOS'22 and the recorded videos, the upcoming SESAME workshop at EuroSys'23
- Fixed other hyperlinks