### PR TITLE
fix the scikit-learn package name

### DIFF
--- a/function-images/lr_serving/requirements.txt
+++ b/function-images/lr_serving/requirements.txt
@@ -2,4 +2,4 @@ futures
 protobuf
 pandas
 grpcio
-sklearn
+scikit-learn


### PR DESCRIPTION
## Summary

package name for sklearn is changed to scikit-learn 

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
