### PR TITLE
fix the scikit-learn package name for lr_training

### DIFF
--- a/function-images/lr_training_s3/requirements.txt
+++ b/function-images/lr_training_s3/requirements.txt
@@ -2,6 +2,6 @@ futures
 protobuf
 pandas
 grpcio
-sklearn
+scikit-learn
 urllib3
 minio


### PR DESCRIPTION
Similar to https://github.com/vhive-serverless/vHive/pull/678
package name for sklearn is changed to scikit-learn

## Summary

A small summary of the requirements (in one/two sentences).

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
