### PR TITLE
GPG Key Workaround

### DIFF
--- a/scripts/install_stock.sh
+++ b/scripts/install_stock.sh
@@ -46,8 +46,7 @@ containerd --version || echo "failed to build containerd"
 
 # Install k8s
 K8S_VERSION=1.23.5-00
-curl --silent --show-error https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-sudo sh -c "echo 'deb http://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list"
+sudo sh -c "echo 'deb [trusted=yes] http://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list"
 sudo apt-get update >> /dev/null
 sudo apt-get -y install cri-tools ebtables ethtool kubeadm=$K8S_VERSION kubectl=$K8S_VERSION kubelet=$K8S_VERSION kubernetes-cni >> /dev/null
 


### PR DESCRIPTION
## Summary

Workaround for GPG key errors in the install script

## Implementation Notes :hammer_and_pick:

* Sets the repo as trusted, meaning GPG keys do not get checked when installing from that repo.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

