### PR TITLE
Change in the image repository for metallb deployments

### DIFF
--- a/scripts/cluster/setup_master_node.sh
+++ b/scripts/cluster/setup_master_node.sh
@@ -36,8 +36,8 @@ kubectl get configmap kube-proxy -n kube-system -o yaml | \
 sed -e "s/strictARP: false/strictARP: true/" | \
 kubectl apply -f - -n kube-system
 
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.4/manifests/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.4/manifests/metallb.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12/manifests/metallb.yaml
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 kubectl apply -f $ROOT/configs/metallb/metallb-configmap.yaml
 


### PR DESCRIPTION
## Summary

The metallb images have shifted the image repositories from docker.io to quay.io. This necessitates a change in the `kubectl apply -f` commands used in the vHive setup for deploying the metallb pods.

## Implementation Notes :hammer_and_pick:

* The main change is in the image name for the metallb deployments. The original images were docker.io based, which have since changed to quay.io. Thus, I created new yaml files with the updated images, and then used these in the `kubectl apply -f` commands, replacing the original file.

## External Dependencies :four_leaf_clover:

* Images on quay.io (https://quay.io/repository/)

## Breaking API Changes :warning:

* The new version of metallb add ons is v0.9.6 on quay.io, instead of the original v0.9.4 on docker.io. I referred to the PR on Kubernetes (https://github.com/kubernetes/minikube/pull/16056) for getting this version.

*Simply specify none (N/A) if not applicable.*
