### PR TITLE
Temporarily disable local registry tests from CRI tests

### DIFF
--- a/cri/Makefile
+++ b/cri/Makefile
@@ -29,11 +29,13 @@ test-cri-firecracker:
 	KUBECONFIG=/etc/kubernetes/admin.conf ./../scripts/setup_zipkin.sh
 	sleep 5s
 
-	go run ./../examples/registry/populate_registry.go -imageFile ./../examples/registry/images.txt
+# FIXME (gh-709)
+#	go run ./../examples/registry/populate_registry.go -imageFile ./../examples/registry/images.txt
 	sleep 1s
 
 	KUBECONFIG=/etc/kubernetes/admin.conf kn service apply helloworld -f ./../configs/knative_workloads/helloworld.yaml
-	KUBECONFIG=/etc/kubernetes/admin.conf kn service apply helloworldlocal -f ./../configs/knative_workloads/helloworld_local.yaml
+# FIXME (gh-709)
+#	KUBECONFIG=/etc/kubernetes/admin.conf kn service apply helloworldlocal -f ./../configs/knative_workloads/helloworld_local.yaml
 	KUBECONFIG=/etc/kubernetes/admin.conf kn service apply helloworldserial -f ./../configs/knative_workloads/helloworldSerial.yaml
 	KUBECONFIG=/etc/kubernetes/admin.conf kn service apply pyaes -f ./../configs/knative_workloads/pyaes.yaml
 	sleep 1m

--- a/cri/cri_test.go
+++ b/cri/cri_test.go
@@ -56,20 +56,22 @@ func TestSingleInvoke(t *testing.T) {
 	invoke(t, functionURL)
 }
 
-func TestSingleInvokeLocal(t *testing.T) {
-	functionURL := getFuncURL("helloworldlocal")
-	invoke(t, functionURL)
-}
+// FIXME (gh-709)
+//func TestSingleInvokeLocal(t *testing.T) {
+//	functionURL := getFuncURL("helloworldlocal")
+//	invoke(t, functionURL)
+//}
 
 func TestParallelInvoke(t *testing.T) {
 	functionURL := getFuncURL("helloworld")
 	parallelInvoke(t, functionURL)
 }
 
-func TestParallelInvokeLocal(t *testing.T) {
-	functionURL := getFuncURL("helloworldlocal")
-	parallelInvoke(t, functionURL)
-}
+// FIXME (gh-709)
+//func TestParallelInvokeLocal(t *testing.T) {
+//	functionURL := getFuncURL("helloworldlocal")
+//	parallelInvoke(t, functionURL)
+//}
 
 func TestAutoscaler(t *testing.T) {
 	cases := []struct {
@@ -115,7 +117,8 @@ func TestMultipleFuncInvoke(t *testing.T) {
 	var wg sync.WaitGroup
 	funcs := []string{
 		"helloworld",
-		"helloworldlocal",
+		// FIXME (gh-709)
+		//"helloworldlocal",
 		"pyaes",
 		// "rnnserving",
 		// This function deployment fails on cri test container


### PR DESCRIPTION
## Summary

Closes #703

## Implementation Notes :hammer_and_pick:

Current vHive CloudLab profile uses Ubuntu 20.04 image, which does not have
the skopeo package which is needed to pull image for local registry tests —
temporarily disable these tests until https://github.com/vhive-serverless/vHive/issues/709 is resolved.

## External Dependencies :four_leaf_clover:

N/A.

## Breaking API Changes :warning:

N/A. 