### PR TITLE
bump action runner image to ubuntu-20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
 
     name: Build and check code quality
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
 
     - name: Set up Go ${{ matrix.go }}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   function_images:
     name: Build function docker images
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +29,7 @@ jobs:
         DOCKER_BUILDKIT=1 docker build ./function-images/${{ matrix.image }}
   integ_test_image:
     name: Build integration test docker images
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Spellcheck
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: rojopolis/spellcheck-github-actions@0.30.0
@@ -17,7 +17,7 @@ jobs:
         config_path: configs/.spellcheck.yml
   commitlint:
     name: Commitlint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -37,7 +37,7 @@ jobs:
           --verbose
   markdown-link-check:
     name: LinkCheck
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
## Summary

update action runner image to ubuntu-20.04 from 18.04 as github is deprecating 18.04

## Implementation Notes :hammer_and_pick:


## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
