### PR TITLE
Remove rnn-serving from example functions

### DIFF
--- a/examples/deployer/functions.json
+++ b/examples/deployer/functions.json
@@ -9,11 +9,6 @@
             "name": "pyaes",
             "file": "pyaes.yaml",
             "count": 2
-        },
-        {
-            "name": "rnn-serving",
-            "file": "rnn_serving.yaml",
-            "count": 3
         }
     ]
 }


### PR DESCRIPTION
## Summary

rnn-serving is known to be unstable.
