### PR TITLE
add google cloud public signing key

### DIFF
--- a/scripts/install_stock.sh
+++ b/scripts/install_stock.sh
@@ -46,7 +46,9 @@ containerd --version || echo "failed to build containerd"
 
 # Install k8s
 K8S_VERSION=1.25.3-00
-sudo sh -c "echo 'deb [trusted=yes] http://apt.kubernetes.io/ kubernetes-xenial main' > /etc/apt/sources.list.d/kubernetes.list"
+sudo mkdir -p /etc/apt/keyrings
+sudo curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo apt-get update >> /dev/null
 sudo apt-get -y install cri-tools ebtables ethtool kubeadm=$K8S_VERSION kubectl=$K8S_VERSION kubelet=$K8S_VERSION kubernetes-cni >> /dev/null
 


### PR DESCRIPTION
## Summary

add google cloud public signing key

## Implementation Notes :hammer_and_pick:

- change public signing key and apt repo script referring to [k8s official document](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management)

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
