### PR TITLE
add logs submodule for logging golang set up scripts

### DIFF
--- a/scripts/easy_openyurt/src/easy_openyurt/logs/go.mod
+++ b/scripts/easy_openyurt/src/easy_openyurt/logs/go.mod
@@ -1,0 +1,3 @@
+module github.com/flyinghorse0510/easy_openyurt/src/easy_openyurt/logs
+
+go 1.20

--- a/scripts/easy_openyurt/src/easy_openyurt/logs/logs.go
+++ b/scripts/easy_openyurt/src/easy_openyurt/logs/logs.go
@@ -1,0 +1,148 @@
+// Author: Haoyuan Ma <flyinghorse0510@zju.edu.cn>
+package logs
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/flyinghorse0510/easy_openyurt/src/easy_openyurt/configs"
+)
+
+var (
+	_colorReset  = "\033[0m"
+	_colorRed    = "\033[31m"
+	_colorGreen  = "\033[32m"
+	_colorYellow = "\033[33m"
+	_colorBlue   = "\033[34m"
+	// _colorPurple = "\033[35m"
+	// _colorCyan   = "\033[36m"
+	// _colorGray   = "\033[37m"
+	// _colorWhite  = "\033[97m"
+)
+
+var (
+	CommonLog *log.Logger = nil // Common logs
+	ErrorLog  *log.Logger = nil // Error logs
+)
+
+// Print colored text in terminal
+func coloredPrintf(color string, format string, pars ...any) {
+	fmt.Print(color)
+	fmt.Printf(format, pars...)
+	fmt.Print(_colorReset)
+}
+
+// Print error message (red) in terminal and send it to the error logs(if exist)
+func ErrorPrintf(format string, pars ...any) {
+	currentTime := time.Now().Local()
+	// For output
+	coloredPrintf(_colorRed, "[%02d:%02d:%02d] [Error] ", currentTime.Hour(), currentTime.Minute(), currentTime.Second())
+	coloredPrintf(_colorRed, format, pars...)
+	// For logs
+	if ErrorLog != nil {
+		ErrorLog.Printf(format, pars...)
+	}
+}
+
+// Print warning message (yellow) in terminal and send it to the common logs(if exist)
+func WarnPrintf(format string, pars ...any) {
+	currentTime := time.Now().Local()
+	// For output
+	coloredPrintf(_colorYellow, "[%02d:%02d:%02d] [Warn] ", currentTime.Hour(), currentTime.Minute(), currentTime.Second())
+	coloredPrintf(_colorYellow, format, pars...)
+	// For logs
+	if CommonLog != nil {
+		CommonLog.Printf(format, pars...)
+	}
+}
+
+// Print success message (green) in terminal and send it to the common logs(if exist)
+func SuccessPrintf(format string, pars ...any) {
+	currentTime := time.Now().Local()
+	// For output
+	coloredPrintf(_colorGreen, "[%02d:%02d:%02d] [Success] ", currentTime.Hour(), currentTime.Minute(), currentTime.Second())
+	coloredPrintf(_colorGreen, format, pars...)
+	// For logs
+	if CommonLog != nil {
+		CommonLog.Printf(format, pars...)
+	}
+}
+
+// Print information (blue) in terminal and send it to the common logs(if exist)
+func InfoPrintf(format string, pars ...any) {
+	currentTime := time.Now().Local()
+	// For output
+	coloredPrintf(_colorBlue, "[%02d:%02d:%02d] [Info] ", currentTime.Hour(), currentTime.Minute(), currentTime.Second())
+	coloredPrintf(_colorBlue, format, pars...)
+	// For logs
+	if CommonLog != nil {
+		CommonLog.Printf(format, pars...)
+	}
+}
+
+// Print information (blue) with waiting symbol in terminal and send it to the common logs(if exist)
+func WaitPrintf(format string, pars ...any) {
+	InfoPrintf(format+" >>>>> ", pars...)
+}
+
+// Call `ErrorPrintf()` and then exit with code 1
+func FatalPrintf(format string, pars ...any) {
+	ErrorPrintf(format, pars...)
+	os.Exit(1)
+}
+
+// If err is not nil, print the error message, send it to the error logs, and then exit
+func CheckErrorWithMsg(err error, format string, pars ...any) {
+	if err != nil {
+		ErrorPrintf("%v\n", err)
+		FatalPrintf(format, pars...)
+	}
+}
+
+// If err is not nil, print the error message, send it to the error logs, and then exit
+// Otherwise, print a success tag
+func CheckErrorWithTagAndMsg(err error, format string, pars ...any) {
+	CheckErrorWithMsg(err, format, pars...)
+	SuccessPrintf("\n")
+}
+
+// Print general usage tips
+func PrintGeneralUsage() {
+	InfoPrintf("Usage: %s <object: system | kube | yurt> <nodeRole: master | worker> <operation: init | join | expand> [Parameters...]\n", os.Args[0])
+}
+
+// Print welcome information
+func PrintWelcomeInfo() {
+	coloredPrintf(_colorGreen, "<<<<<<<<< EasyOpenYurt %s >>>>>>>>>\n", configs.Version)
+}
+
+// Print warning information
+func PrintWarningInfo() {
+	WarnPrintf("THIS IS AN EXPERIMENTAL PROGRAM DEVELOPED PERSONALLY\n")
+	WarnPrintf("DO NOT ATTEMPT TO USE IN PRODUCTION ENVIRONMENT!\n")
+	WarnPrintf("MAKE SURE TO BACK UP YOUR SYSTEM AND TAKE CARE!\n")
+}
+
+// Create Logs
+func CreateLogs(logDir string) {
+	// notify user
+	WaitPrintf("Creating log files")
+
+	// create log files
+	commonLogFile, err := os.OpenFile(logDir+"/easyOpenYurtCommon.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	CheckErrorWithMsg(err, "Failed to create log files!\n")
+
+	errorLogFile, err := os.OpenFile(logDir+"/easyOpenYurtError.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	CheckErrorWithMsg(err, "Failed to create log files!\n")
+
+	// create Logger
+	CommonLog = log.New(commonLogFile, "INFO: ", log.Ltime|log.Lshortfile)
+	ErrorLog = log.New(errorLogFile, "ERROR: ", log.Ltime|log.Lshortfile)
+
+	// Success
+	SuccessPrintf("\n")
+	SuccessPrintf("Stdout Log -> %s/easyOpenYurtCommon.log\n", logDir)
+	SuccessPrintf("Stderr Log -> %s/easyOpenYurtError.log\n", logDir)
+}

--- a/scripts/easy_openyurt/src/easy_openyurt/logs/logs_test.go
+++ b/scripts/easy_openyurt/src/easy_openyurt/logs/logs_test.go
@@ -1,0 +1,17 @@
+package logs
+
+import (
+	"testing"
+)
+
+func TestColorfulPrint(t *testing.T) {
+	ErrorPrintf("Here is an error message\n")
+	WarnPrintf("Here is a warning message\n")
+	SuccessPrintf("Here is a successful message\n")
+	InfoPrintf("Here is a information message\n")
+}
+func TestCreateLogs(t *testing.T) {
+	CreateLogs(".")
+	CommonLog.Printf("This is a common log file\n")
+	ErrorLog.Printf("This is an error log file\n")
+}


### PR DESCRIPTION
**This PR contains logs submodule for logging golang setup scripts**
## Recommended Review Orders:
**logs\*(this PR)** --> **system** --> **kube** --> **knative(vhive)** --> **configs**
## Batch PRs overall content
 > Files with `*` are included in this PR

.
├── README.md
├── src
│   └── easy_openyurt
│       ├── build.sh
│       ├── configs
│       │   ├── configs.go
│       │   ├── go.mod
│       │   ├── knative.go
│       │   ├── kube.go
│       │   ├── loader.go
│       │   ├── system.go
│       │   ├── vhive.go
│       │   └── yurt.go
│       ├── go.mod
│       ├── go.work
│       ├── knative
│       │   ├── go.mod
│       │   └── knative.go
│       ├── kube
│       │   ├── go.mod
│       │   └── kube.go
│       ├── **logs**\*
│       │   ├── **go.mod**\*
│       │   ├── **logs.go**\*
│       │   └── **logs_test.go**\*
│       ├── main.go
│       ├── system
│       │   ├── go.mod
│       │   ├── system.go
│       │   └── system_test.go
│       ├── template
│       │   ├── go.mod
│       │   ├── kubeTemplate.go
│       │   ├── shellTemplate.go
│       │   ├── template.go
│       │   └── yurtTemplate.go
│       ├── vhive
│       │   ├── go.mod
│       │   └── vhive.go
│       └── yurt
│           ├── go.mod
│           └── yurt.go
└── template
    ├── busyBoxTemplate.yaml
    ├── kubeletTemplate.yaml
    ├── masterNodePoolTemplate.yaml
    ├── nginxDefault.yaml
    ├── nginxService.yaml
    ├── nginxYurt.yaml
    ├── workerNodePoolTemplate.yaml
    └── yurthubTemplate.yaml

11 directories, 40 files

