### PR TITLE
Make runner type configurable for CRI workflows

### DIFF
--- a/.github/workflows/cri_tests.yml
+++ b/.github/workflows/cri_tests.yml
@@ -6,6 +6,9 @@ on:
       sandbox:
         required: true
         type: string
+      runnerType:
+        required: true
+        type: string
 
 env:
   GO111MODULE: on
@@ -16,7 +19,8 @@ jobs:
     env:
       GITHUB_RUN_ID: ${{ github.run_id }}
       GITHUB_VHIVE_ARGS: "-dbg"
-    runs-on: ${{ fromJSON(format('["self-hosted", "{0}-cri"]', inputs.sandbox)) }}
+    #runs-on: ${{ fromJSON(format('["{0}", "{1}-cri"]', inputs.runnerType, inputs.sandbox)) }}
+    runs-on: ${{ inputs.runnerType }}
 
     steps:
 

--- a/.github/workflows/firecracker_cri_tests.yml
+++ b/.github/workflows/firecracker_cri_tests.yml
@@ -23,3 +23,4 @@ jobs:
     uses: ./.github/workflows/cri_tests.yml
     with:
       sandbox: firecracker
+      runnerType: self-hosted

--- a/.github/workflows/gvisor_cri_tests.yml
+++ b/.github/workflows/gvisor_cri_tests.yml
@@ -20,6 +20,50 @@ env:
 
 jobs:
   gvisor-cri-tests:
-    uses: ./.github/workflows/cri_tests.yml
-    with:
-      sandbox: gvisor
+    name: CRI tests
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    #    uses: ./.github/workflows/cri_tests.yml
+    #    with:
+    #      sandbox: gvisor
+    #      runnerType: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: "true"
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+
+      - name: Create k8s Kind Cluster
+        run: bash ./scripts/stargz/01-kind.sh
+
+      - name: Install Serving
+        run: bash ./scripts/stargz/02-serving.sh
+
+      - name: Install Kourier
+        run: bash ./scripts/stargz/02-kourier.sh
+
+      - name: Setup domain and autoscaler
+        run: |
+          INGRESS_HOST="127.0.0.1"
+          KNATIVE_DOMAIN=$INGRESS_HOST.sslip.io
+          kubectl patch configmap -n knative-serving config-domain -p "{\"data\": {\"$KNATIVE_DOMAIN\": \"\"}}"
+          kubectl patch configmap -n knative-serving config-autoscaler -p "{\"data\": {\"allow-zero-initial-scale\": \"true\"}}"
+
+      - name: Setup stock-only node
+        run: ./scripts/cloudlab/setup_node.sh gvisor
+
+      - name: Check containerd service is running
+        run: sudo screen -list | grep "containerd"
+
+      - name: Create helloworld container
+        run: kn service create helloworld-go --image gcr.io/knative-samples/helloworld-go --env TARGET="vHive CRI test"
+
+      - name: Invoke the deployed function
+        run: curl http://helloworld-go.default.192.168.1.240.sslip.io


### PR DESCRIPTION
## Summary

Make runner type configurable in the CRI tests. In particular, I would like to check if gvisor CRI can work on github-hosted runners.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
