### PR TITLE
add schedule to run all self-hosted tests weekly

### DIFF
--- a/.github/workflows/cri_stock_containerd_test.yml
+++ b/.github/workflows/cri_stock_containerd_test.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 9 * * *'
+    - cron: '0 19 * * 1'
 
 env:
   GOOS: linux

--- a/.github/workflows/firecracker_cri_tests.yml
+++ b/.github/workflows/firecracker_cri_tests.yml
@@ -14,6 +14,8 @@ on:
       - '**.md'
       - 'function-images/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 19 * * 1'
 
 env:
   GO111MODULE: on

--- a/.github/workflows/gvisor_cri_tests.yml
+++ b/.github/workflows/gvisor_cri_tests.yml
@@ -14,6 +14,8 @@ on:
     - '**.md'
     - 'function-images/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 19 * * 1'
 
 env:
   GO111MODULE: on

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,6 +14,8 @@ on:
     - '**.md'
     - 'function-images/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 19 * * 1'
 
 env:
   GOOS: linux

--- a/scripts/go.work
+++ b/scripts/go.work
@@ -9,4 +9,5 @@ use (
 	./setup
 	./stargz
 	./utils
+	./github_runner
 )


### PR DESCRIPTION
## Summary

Add schedule event trigger to all the four self-hosted tests to make them run weekly

## Implementation Notes :hammer_and_pick:

Add crons to the .github/ files

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
