### PR TITLE
Temporarily disable UPF feature and tests on `firecracker-v1.4.1-vhive-integration` branch

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -58,7 +58,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vhive_args: ["-dbg", "-dbg -snapshots", "-dbg -snapshots -upf"]
+        # User-level page faults are temporarily disabled (gh-807)
+        # vhive_args: ["-dbg", "-dbg -snapshots", "-dbg -snapshots -upf"]
+        vhive_args: [ "-dbg", "-dbg -snapshots" ]
     env:
         GITHUB_RUN_ID: ${{ github.run_id }}
         GITHUB_JOB: ${{ github.job }}

--- a/ctriface/Makefile
+++ b/ctriface/Makefile
@@ -23,7 +23,9 @@
 EXTRAGOARGS:=-v -race -cover
 EXTRATESTFILES:=iface_test.go iface.go orch_options.go orch.go
 BENCHFILES:=bench_test.go iface.go orch_options.go orch.go
-WITHUPF:=-upf
+# User-level page faults are temporarily disabled (gh-807)
+# WITHUPF:=-upf
+WITHUPF:=
 WITHLAZY:=-lazy
 GOBENCH:=-v -timeout 1500s
 CTRDLOGDIR:=/tmp/ctrd-logs

--- a/ctriface/iface_test.go
+++ b/ctriface/iface_test.go
@@ -41,8 +41,19 @@ var (
 	isUPFEnabled = flag.Bool("upf", false, "Set UPF enabled")
 	isLazyMode   = flag.Bool("lazy", false, "Set lazy serving on or off")
 	//nolint:deadcode,unused,varcheck
-	isWithCache  = flag.Bool("withCache", false, "Do not drop the cache before measurements")
+	isWithCache = flag.Bool("withCache", false, "Do not drop the cache before measurements")
 )
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if *isUPFEnabled {
+		log.Error("User-level page faults are temporarily disabled (gh-807)")
+		os.Exit(-1)
+	}
+
+	os.Exit(m.Run())
+}
 
 func TestPauseSnapResume(t *testing.T) {
 	log.SetFormatter(&log.TextFormatter{

--- a/vhive.go
+++ b/vhive.go
@@ -89,6 +89,11 @@ func main() {
 		return
 	}
 
+	if *isUPFEnabled {
+		log.Error("User-level page faults are temporarily disabled (gh-807)")
+		return
+	}
+
 	if *isUPFEnabled && !*isSnapshotsEnabled {
 		log.Error("User-level page faults are not supported without snapshots")
 		return

--- a/vhive_test.go
+++ b/vhive_test.go
@@ -65,6 +65,11 @@ func TestMain(m *testing.M) {
 
 	flag.Parse()
 
+	if *isUPFEnabled {
+		log.Error("User-level page faults are temporarily disabled (gh-807)")
+		os.Exit(-1)
+	}
+
 	log.Infof("Orchestrator snapshots enabled: %t", *isSnapshotsEnabledTest)
 	log.Infof("Orchestrator UPF enabled: %t", *isUPFEnabledTest)
 	log.Infof("Orchestrator lazy serving mode enabled: %t", *isLazyModeTest)


### PR DESCRIPTION
## Summary

UPF feature for vanilla firecracker requires a separate integration effort (#807), so temporarily disable this feature and all tests for it.

## Implementation Notes :hammer_and_pick:

* vHive and the vHive and orchestrator tests now exit with an error when UPF is enabled. 
* Tests using UPF are simply commented out.

## External Dependencies :four_leaf_clover:

* N/A.

## Breaking API Changes :warning:

* N/A.
