### PR TITLE
redeploy cri tests nightly

### DIFF
--- a/scripts/github_runner/setup_bare_metal_runner.sh
+++ b/scripts/github_runner/setup_bare_metal_runner.sh
@@ -36,6 +36,16 @@ GH_ORG=$1
 GH_PAT=$2
 SANDBOX=$3
 
+# clean the service file before proceeding
+pattern="/etc/systemd/system/actions.runner.vhive-serverless-vhive.*.service"
+if ls $pattern 1> /dev/null 2>&1; then
+  rm $pattern
+  echo "Deleted runner service file."
+else
+  echo "No service file, no need to clean"
+fi
+
+
 VHIVE_ROOT="$(git rev-parse --show-toplevel)"
 "$VHIVE_ROOT"/scripts/cloudlab/setup_node.sh "$SANDBOX"
 


### PR DESCRIPTION
## Summary

Add re-deployment steps to cri-runners. Now re-deployment will be run: 1. nightly 2. before every check


## Implementation Notes :hammer_and_pick:

1. Add a new step in cri-tests: before every check, it will first re-deploy the runner
2. deployer.go now will add a cron task in 4:10am, try to re-deploy the runner nightly
3. In setup_bare_metal_runner.sh, rm the previously created service file so the re-deployment can be done without any error 

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
