### PR TITLE
Encapsulate the host interface name into the VM pool and tap manager

### DIFF
--- a/cri/firecracker/service.go
+++ b/cri/firecracker/service.go
@@ -216,5 +216,5 @@ func getEnvVal(key string, config *criapi.ContainerConfig) (string, error) {
 
 	}
 
-	return "", errors.New("failed to provide non empty guest image in user container config")
+	return "", errors.New("failed to retrieve environment variable from user container config")
 }

--- a/ctriface/iface.go
+++ b/ctriface/iface.go
@@ -79,7 +79,7 @@ func (o *Orchestrator) StartVMWithEnvironment(ctx context.Context, vmID, imageNa
 	logger := log.WithFields(log.Fields{"vmID": vmID, "image": imageName})
 	logger.Debug("StartVM: Received StartVM")
 
-	vm, err := o.vmPool.Allocate(vmID, o.hostIface)
+	vm, err := o.vmPool.Allocate(vmID)
 	if err != nil {
 		logger.Error("failed to allocate VM in VM pool")
 		return nil, nil, err
@@ -504,7 +504,7 @@ func (o *Orchestrator) Offload(ctx context.Context, vmID string) error {
 		return err
 	}
 
-	if err := o.vmPool.RecreateTap(vmID, o.hostIface); err != nil {
+	if err := o.vmPool.RecreateTap(vmID); err != nil {
 		logger.Error("Failed to recreate tap upon offloading")
 		return err
 	}

--- a/ctriface/orch.go
+++ b/ctriface/orch.go
@@ -87,7 +87,6 @@ type Orchestrator struct {
 	isLazyMode       bool
 	snapshotsDir     string
 	isMetricsMode    bool
-	hostIface        string
 
 	memoryManager *manager.MemoryManager
 }
@@ -97,15 +96,15 @@ func NewOrchestrator(snapshotter, hostIface string, opts ...OrchestratorOption) 
 	var err error
 
 	o := new(Orchestrator)
-	o.vmPool = misc.NewVMPool()
 	o.cachedImages = make(map[string]containerd.Image)
 	o.snapshotter = snapshotter
 	o.snapshotsDir = "/fccd/snapshots"
-	o.hostIface = hostIface
 
 	for _, opt := range opts {
 		opt(o)
 	}
+
+	o.vmPool = misc.NewVMPool(hostIface)
 
 	if _, err := os.Stat(o.snapshotsDir); err != nil {
 		if !os.IsNotExist(err) {

--- a/ctriface/orch_options.go
+++ b/ctriface/orch_options.go
@@ -72,11 +72,3 @@ func WithMetricsMode(isMetricsMode bool) OrchestratorOption {
 		o.isMetricsMode = isMetricsMode
 	}
 }
-
-// WithCustomHostIface Sets the custom host net interface
-// for the VMs to link to
-func WithCustomHostIface(hostIface string) OrchestratorOption {
-	return func(o *Orchestrator) {
-		o.hostIface = hostIface
-	}
-}

--- a/misc/misc_test.go
+++ b/misc/misc_test.go
@@ -48,12 +48,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestAllocateFreeVMs(t *testing.T) {
-	vmPool := NewVMPool()
+	vmPool := NewVMPool("")
 
 	vmIDs := [2]string{"test1", "test2"}
 
 	for _, vmID := range vmIDs {
-		_, err := vmPool.Allocate(vmID, "")
+		_, err := vmPool.Allocate(vmID)
 		require.NoError(t, err, "Failed to allocate VM")
 	}
 
@@ -68,7 +68,7 @@ func TestAllocateFreeVMs(t *testing.T) {
 func TestAllocateFreeVMsParallel(t *testing.T) {
 	vmNum := 100
 
-	vmPool := NewVMPool()
+	vmPool := NewVMPool("")
 
 	var vmGroup sync.WaitGroup
 	for i := 0; i < vmNum; i++ {
@@ -76,7 +76,7 @@ func TestAllocateFreeVMsParallel(t *testing.T) {
 		go func(i int) {
 			defer vmGroup.Done()
 			vmID := fmt.Sprintf("test_%d", i)
-			_, err := vmPool.Allocate(vmID, "")
+			_, err := vmPool.Allocate(vmID)
 			require.NoError(t, err, "Failed to allocate VM")
 		}(i)
 	}
@@ -100,7 +100,7 @@ func TestAllocateFreeVMsParallel(t *testing.T) {
 func TestRecreateParallel(t *testing.T) {
 	vmNum := 100
 
-	vmPool := NewVMPool()
+	vmPool := NewVMPool("")
 
 	var vmGroup sync.WaitGroup
 	for i := 0; i < vmNum; i++ {
@@ -108,7 +108,7 @@ func TestRecreateParallel(t *testing.T) {
 		go func(i int) {
 			defer vmGroup.Done()
 			vmID := fmt.Sprintf("test_%d", i)
-			_, err := vmPool.Allocate(vmID, "")
+			_, err := vmPool.Allocate(vmID)
 			require.NoError(t, err, "Failed to allocate VM")
 		}(i)
 	}
@@ -123,7 +123,7 @@ func TestRecreateParallel(t *testing.T) {
 		go func(i int) {
 			defer vmGroupRecreate.Done()
 			vmID := fmt.Sprintf("test_%d", i)
-			err := vmPool.RecreateTap(vmID, "")
+			err := vmPool.RecreateTap(vmID)
 			require.NoError(t, err, "Failed to recreate tap")
 		}(i)
 	}

--- a/taps/taps_test.go
+++ b/taps/taps_test.go
@@ -50,14 +50,14 @@ func TestMain(m *testing.M) {
 }
 
 func TestCreateCleanBridges(t *testing.T) {
-	tm := NewTapManager()
+	tm, _ := NewTapManager("")
 	tm.RemoveBridges()
 }
 
 func TestCreateRemoveTaps(t *testing.T) {
 	tapsNum := []int{100, 1100}
 
-	tm := NewTapManager()
+	tm, _ := NewTapManager("")
 	defer tm.RemoveBridges()
 
 	for _, n := range tapsNum {
@@ -66,7 +66,7 @@ func TestCreateRemoveTaps(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				_, _ = tm.AddTap(fmt.Sprintf("tap_%d", i), "")
+				_, _ = tm.AddTap(fmt.Sprintf("tap_%d", i))
 			}(i)
 		}
 		wg.Wait()
@@ -87,11 +87,11 @@ func TestCreateRemoveExtra(t *testing.T) {
 
 	tapsNum := 2001
 
-	tm := NewTapManager()
+	tm, _ := NewTapManager("")
 	defer tm.RemoveBridges()
 
 	for i := 0; i < tapsNum; i++ {
-		_, err := tm.AddTap(fmt.Sprintf("tap_%d", i), "")
+		_, err := tm.AddTap(fmt.Sprintf("tap_%d", i))
 		if i < tm.numBridges*TapsPerBridge {
 			require.NoError(t, err, "Failed to create tap")
 		} else {

--- a/taps/types.go
+++ b/taps/types.go
@@ -38,6 +38,7 @@ const (
 // TapManager A Tap Manager
 type TapManager struct {
 	sync.Mutex
+	hostIfaceName      string
 	numBridges         int
 	TapCountsPerBridge []int64
 	createdTaps        map[string]*NetworkInterface


### PR DESCRIPTION
#### Fix typo in `getEnvVal` error message

#### Encapsulate the host interface name into the VM pool and tap manager

Currently, the host interface name is separated from the VM pool and tap
manager, and as a result, it needs to be passed to all VM pool methods.

This is inconvenient, and so encapsulate the host interface name into the
VM pool and tap manager.

Closes #810
Part of #794

## Implementation Notes :hammer_and_pick:

* The host interface name is encapsulated into the VM pool and tap manager.

## External Dependencies :four_leaf_clover:

* N/A.

## Breaking API Changes :warning:

* N/A.

*Simply specify none (N/A) if not applicable.*
