### PR TITLE
Various enhancements to the vHive function pool

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -358,7 +358,7 @@ func (f *Function) AddInstance() *metrics.Metric {
 	if f.isSnapshotReady {
 		var resp *ctriface.StartVMResponse
 		
-		resp, metr = f.LoadInstance()
+		resp, metr = f.LoadInstance(f.vmID)
 		f.guestIP = resp.GuestIP
 	} else {
 		resp, _, err := orch.StartVM(ctx, f.getVMID(), f.imageName)
@@ -485,7 +485,7 @@ func (f *Function) OffloadInstance() {
 
 // LoadInstance Loads a new instance of the function from its snapshot and resumes it
 // The tap, the shim and the vmID remain the same
-func (f *Function) LoadInstance() (*ctriface.StartVMResponse, *metrics.Metric) {
+func (f *Function) LoadInstance(vmID string) (*ctriface.StartVMResponse, *metrics.Metric) {
 	logger := log.WithFields(log.Fields{"fID": f.fID})
 
 	logger.Debug("Loading instance")
@@ -494,12 +494,12 @@ func (f *Function) LoadInstance() (*ctriface.StartVMResponse, *metrics.Metric) {
 	defer cancel()
 
 	snap := snapshotting.NewSnapshot(f.vmID, "/fccd/snapshots", f.imageName)
-	resp, loadMetr, err := orch.LoadSnapshot(ctx, f.vmID, snap)
+	resp, loadMetr, err := orch.LoadSnapshot(ctx, vmID, snap)
 	if err != nil {
 		log.Panic(err)
 	}
 
-	resumeMetr, err := orch.ResumeVM(ctx, f.vmID)
+	resumeMetr, err := orch.ResumeVM(ctx, vmID)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/functions.go
+++ b/functions.go
@@ -391,12 +391,12 @@ func (f *Function) RemoveInstanceAsync() {
 
 	logger.Debug("Removing instance (async)")
 
-	go func() {
-		err := orch.StopSingleVM(context.Background(), f.vmID)
+	go func(vmID string) {
+		err := orch.StopSingleVM(context.Background(), vmID)
 		if err != nil {
 			log.Warn(err)
 		}
-	}()
+	}(f.vmID)
 }
 
 // RemoveInstance Stops an instance (VM) of the function.


### PR DESCRIPTION
## Summary

### Propagate `StartVMResponse` from `Orch:LoadSnapshot` to `Func:LoadInstance`

This will come in handy when the loaded instance will be a snapshot booted
VM rather than an offloaded one.

### Pass VM ID of function by value in goroutine for async instance removal

Goroutines capture variables by reference, so it is safer to make a copy
(i.e., a local variable) and pass the variable by value.

This will also come in handy when the function's VM ID can change when it
is loaded from a snapshot booted VM rather than an offloaded one.

### Pass VM ID to `Function:LoadInstance` instead of relying on existing one

This will come in handy when the function's VM ID will be assigned to
it after a VM for it is loaded from a snapshot (i.e., a new VM is created
rather than an offloaded one is reused). This logic follows the branch when
a snapshot is not available and a VM is booted from scratch.

## Implementation Notes :hammer_and_pick:

* Replace manually created snapshots with snapshot manager in function pool;
* Propagate `StartVMResponse` from `Orch:LoadSnapshot` to `Func:LoadInstance`;
* Pass VM ID of function by value in goroutine for async instance removal (`RemoveInstanceAsync`);
* Pass VM ID to `Function:LoadInstance` instead of relying on existing one.

## External Dependencies :four_leaf_clover:

* N/A.

## Breaking API Changes :warning:

* N/A.