### PR TITLE
Increase timeout for MetalLB setup

### DIFF
--- a/scripts/cluster/setup_master_node.go
+++ b/scripts/cluster/setup_master_node.go
@@ -125,7 +125,7 @@ func InstallMetalLB() error {
 	if !utils.CheckErrorWithMsg(err, "Failed to install and configure MetalLB!\n") {
 		return err
 	}
-	_, err = utils.ExecShellCmd("kubectl -n metallb-system wait deploy controller --timeout=90s --for=condition=Available")
+	_, err = utils.ExecShellCmd("kubectl -n metallb-system wait deploy controller --timeout=180s --for=condition=Available")
 	if !utils.CheckErrorWithMsg(err, "Failed to install and configure MetalLB!\n") {
 		return err
 	}


### PR DESCRIPTION
## Summary

On tutorial VMs setting up regularly fails due to timed out MetalLB services. In the end they are fine, just too long to be created.

## Implementation Notes :hammer_and_pick:

* Increase timeout for deploying MetalLB cintroller.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
