### PR TITLE
remove pmu tool

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -53,8 +53,8 @@ jobs:
     - name: Setup System
       run: ./scripts/setup_tool setup_system
 
-    - name: Install PMU tools
-      run: ./scripts/setup_tool install_pmutools
+    # - name: Install PMU tools
+    #   run: ./scripts/setup_tool install_pmutools
 
     - name: Build
       run: go build -race -v -a ./...

--- a/profile/Makefile
+++ b/profile/Makefile
@@ -1,7 +1,7 @@
 EXTRAGOARGS:=-v -race -cover
 
 test:
-	sudo env "PATH=$(PATH)" go test ./ $(EXTRAGOARGS)
+	sudo env "PATH=$(PATH)" go test ./plotter*.go $(EXTRAGOARGS)
 
 test-man:
 	echo "Nothing to test manually"


### PR DESCRIPTION
## Summary

Remove pmu tool from unit test, it cannot detect CPU in github runners

## Implementation Notes :hammer_and_pick:

* Comment out the workflow file for installing PMU tool
* Disable the profiler test

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
