### PR TITLE
Install configurable version of go

### DIFF
--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -45,9 +45,9 @@ SSD-equipped nodes are highly recommended. Full list of CloudLab nodes can be fo
 
 ### 4. Go Installation
 
-If you intend to build the setup scripts from source, you can refer to the [Go Installation Guide](https://go.dev/doc/install) for installing Go on your system. **We highly recommend you install Go with version `1.19`**
+If you intend to build the setup scripts from source, you need to install go by running `./scripts/install_go.sh; source /etc/profile`.
 
-Another option is to run `./scripts/install_go.sh; source /etc/profile`, this will install version `1.18`.
+This will install version `1.19.10`. You can configure the version to install in `configs/setup/system.json` as `GoVersion`.
 
 - Confirm the installation:
    ```bash

--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -24,9 +24,31 @@
 
 set -e
 
-wget --continue --quiet https://golang.org/dl/go1.18.linux-amd64.tar.gz
+VHIVE_ROOT="$(git rev-parse --show-toplevel)"
 
-sudo tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+arch=`uname -m`
+
+case $arch in
+  'x86_64')
+    arch='amd64'
+    ;;
+  *)
+    echo "Unsupported architecture $arch"
+    exit 1
+    ;;
+esac
+
+sudo apt update; sudo apt install jq -y
+
+go_version=`cat $VHIVE_ROOT/configs/setup/system.json | jq '.GoVersion' | sed 's/"//g'`
+go_link=`cat $VHIVE_ROOT/configs/setup/system.json | jq '.GoDownloadUrlTemplate' | sed 's/"//g'`
+go_link=`echo $go_link | sed 's/%s/'$go_version'/' | sed 's/%s/'$arch'/'`
+
+echo Installing go version $go_version
+
+wget --continue --quiet $go_link
+
+sudo tar -C /usr/local -xzf ${go_link##*/}
 
 export PATH=$PATH:/usr/local/go/bin
 


### PR DESCRIPTION
## Summary

Install version of go configured in configs/setup/system.json by script. That will simplify the manual setup stage. Closes #851.

## Implementation Notes :hammer_and_pick:

* Use jq to parse the config, install go by downloading the archive and decompressing it.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
