### PR TITLE
hotfix to make vhive work on new package repository

### DIFF
--- a/scripts/cluster/create_multinode_cluster.go
+++ b/scripts/cluster/create_multinode_cluster.go
@@ -74,7 +74,7 @@ func CreateMultinodeCluster(stockContainerd string) error {
 // Create kubelet service on master node
 func CreateMasterKubeletService() error {
 	utils.WaitPrintf("Creating kubelet service")
-	bashCmd := `sudo sh -c 'cat <<EOF > /etc/systemd/system/kubelet.service.d/0-containerd.conf
+	bashCmd := `sudo sh -c 'cat <<EOF > /usr/lib/systemd/system/kubelet.service.d/0-containerd.conf
 [Service]
 Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --v=%d --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
 EOF'`
@@ -103,7 +103,7 @@ func DeployKubernetes() error {
 --cri-socket /run/containerd/containerd.sock \
 --kubernetes-version %s \
 --pod-network-cidr="%s" `,
-	configs.System.LogVerbosity, masterNodeIp, configs.Kube.K8sVersion, configs.Kube.PodNetworkCidr)
+		configs.System.LogVerbosity, masterNodeIp, configs.Kube.K8sVersion, configs.Kube.PodNetworkCidr)
 	if len(configs.Kube.AlternativeImageRepo) > 0 {
 		shellCmd = fmt.Sprintf(shellCmd+"--image-repository %s ", configs.Kube.AlternativeImageRepo)
 	}

--- a/scripts/cluster/setup_worker_kubelet.go
+++ b/scripts/cluster/setup_worker_kubelet.go
@@ -46,11 +46,11 @@ func SetupWorkerKubelet(stockContainerd string) error {
 func CreateWorkerKubeletService(criSock string) error {
 	utils.WaitPrintf("Creating kubelet service")
 	// Create service directory if not exist
-	_, err := utils.ExecShellCmd("sudo mkdir -p /etc/systemd/system/kubelet.service.d")
+	_, err := utils.ExecShellCmd("sudo mkdir -p /usr/lib/systemd/system/kubelet.service.d")
 	if !utils.CheckErrorWithMsg(err, "Failed to create kubelet service!\n") {
 		return err
 	}
-	bashCmd := "sudo sh -c 'cat <<EOF > /etc/systemd/system/kubelet.service.d/0-containerd.conf\n" +
+	bashCmd := "sudo sh -c 'cat <<EOF > /usr/lib/systemd/system/kubelet.service.d/0-containerd.conf\n" +
 		"[Service]\n" +
 		`Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --v=%d --runtime-request-timeout=15m --container-runtime-endpoint=unix://%s"` +
 		"\nEOF'"


### PR DESCRIPTION
WARN: will break all features except stock-only; opened issue to k8s

## Summary
Before migrating to `pkgs.k8s.io`, `10-kubeadm.conf` was located in `/etc/systemd/system/kubelet.service.d`
After Migrating, `10-kubeadm.conf` is located in `/usr/lib/systemd/system/kubelet.service.d/`

https://github.com/kubernetes/release/issues/3392
Currently opened an issue.
It seems that /usr/lib is default option for centOS and /etc is default on Ubuntu/Debian, and after migration, it seems that they removed this per-OS option (take a look at the conversation above)