### PR TITLE
Update firecracker kernel image link

### DIFF
--- a/configs/setup/vhive.json
+++ b/configs/setup/vhive.json
@@ -1,4 +1,4 @@
 {
-	"FirecrackerKernelImgDownloadUrl": "https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin",
+	"FirecrackerKernelImgDownloadUrl": "https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.5/x86_64/vmlinux-5.10.186",
 	"StargzVersion": "0.13.0"
 }

--- a/scripts/cluster/setup_master_node.go
+++ b/scripts/cluster/setup_master_node.go
@@ -204,7 +204,7 @@ func InstallKnativeServingComponent(stockContainerd string) error {
 		if !utils.CheckErrorWithMsg(err, "Failed to install Knative Serving component!\n") {
 			return err
 		}
-		
+
 		if _, err = os.Stat(path.Join(configs.VHive.VHiveRepoPath, path.Join("configs/knative_yamls", "serving-core.yaml"))); err != nil {
 			utils.WaitPrintf("Using stock version of knative.")
 			_, err = utils.ExecShellCmd("kubectl apply -f https://github.com/knative/serving/releases/download/knative-v%s/serving-core.yaml", configs.Knative.KnativeVersion)
@@ -291,7 +291,7 @@ func ConfigureMagicDNS() error {
 // Deploy Istio pods
 func DeployIstioPods() error {
 	utils.WaitPrintf("Deploying istio pods")
-	
+
 	if _, err := os.Stat(path.Join(configs.VHive.VHiveRepoPath, path.Join("configs/knative_yamls", "net-istio.yaml"))); err != nil {
 		_, err = utils.ExecShellCmd("kubectl apply -f https://github.com/knative/net-istio/releases/download/knative-v%s/net-istio.yaml", configs.Knative.KnativeVersion)
 		if !utils.CheckErrorWithTagAndMsg(err, "Failed to deploy istio pods!\n") {

--- a/scripts/github_runner/Dockerfile.github_runner
+++ b/scripts/github_runner/Dockerfile.github_runner
@@ -54,7 +54,7 @@ RUN apt-get update && \
     sudo mkdir -p /etc/firecracker-containerd && \
     sudo mkdir -p /var/lib/firecracker-containerd/runtime && \
     sudo mkdir -p /etc/containerd/ && \
-    sudo curl -fsSL -o /var/lib/firecracker-containerd/runtime/hello-vmlinux.bin https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin
+    sudo curl -fsSL -o /var/lib/firecracker-containerd/runtime/hello-vmlinux.bin https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.5/x86_64/vmlinux-5.10.186
 
 COPY scripts/github_runner/setup_runner.sh /setup_runner.sh
 COPY scripts/create_devmapper.sh /create_devmapper.sh

--- a/scripts/setup_firecracker_containerd.sh
+++ b/scripts/setup_firecracker_containerd.sh
@@ -46,7 +46,7 @@ done
 # rootfs image
 sudo cp $BINS/default-rootfs.img /var/lib/firecracker-containerd/runtime/
 # kernel image
-sudo curl -fsSL -o /var/lib/firecracker-containerd/runtime/hello-vmlinux.bin https://s3.amazonaws.com/spec.ccfc.min/img/hello/kernel/hello-vmlinux.bin
+sudo curl -fsSL -o /var/lib/firecracker-containerd/runtime/hello-vmlinux.bin https://s3.amazonaws.com/spec.ccfc.min/firecracker-ci/v1.5/x86_64/vmlinux-5.10.186
 
 sudo cp $CONFIGS/config.toml /etc/firecracker-containerd/
 


### PR DESCRIPTION
## Summary

To support vanilla firecracker UPF features integration, update the current Firecracker kernel image link.

## Implementation Notes :hammer_and_pick:

* Update firecracker kernel image download URL and config in scripts and GitHub runner

## External Dependencies :four_leaf_clover:

* https://github.com/firecracker-microvm/firecracker/blob/main/docs/getting-started.md#getting-a-rootfs-and-guest-kernel-image

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
