### PR TITLE
add go.work

### DIFF
--- a/scripts/go.work
+++ b/scripts/go.work
@@ -1,0 +1,6 @@
+go 1.19
+
+use (
+    .
+    ./github_runner
+)


### PR DESCRIPTION
## Summary

Two months ago, In this PR: https://github.com/vhive-serverless/vHive/pull/881, go.work was deleted.
However, today I noticed if we want to run `go build` under `vHive/scripts/github_runner` to build runner deployment binary tool, we need to add `go.work` under the parent directory of `vHive/scripts/github_runner`.
This makes sense since the setup tool is a separate module with `github_runner` deployment tool

## Implementation Notes :hammer_and_pick:

Add `go.work` under `vHive/scripts`, listing `.` and `./github_runner`

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
