### PR TITLE
Fix firecracker related issues

### DIFF
--- a/scripts/cluster/create_multinode_cluster.go
+++ b/scripts/cluster/create_multinode_cluster.go
@@ -74,11 +74,15 @@ func CreateMultinodeCluster(stockContainerd string) error {
 // Create kubelet service on master node
 func CreateMasterKubeletService() error {
 	utils.WaitPrintf("Creating kubelet service")
-	bashCmd := `sudo sh -c 'cat <<EOF > /usr/lib/systemd/system/kubelet.service.d/0-containerd.conf
-[Service]
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --v=%d --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+	// Create service directory if not exist
+	_, err := utils.ExecShellCmd("sudo mkdir -p /etc/sysconfig")
+	if !utils.CheckErrorWithMsg(err, "Failed to create kubelet service!\n") {
+		return err
+	}
+	bashCmd := `sudo sh -c 'cat <<EOF > /etc/sysconfig/kubelet
+KUBELET_EXTRA_ARGS="--container-runtime=remote --v=%d --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
 EOF'`
-	_, err := utils.ExecShellCmd(bashCmd, configs.System.LogVerbosity)
+	_, err = utils.ExecShellCmd(bashCmd, configs.System.LogVerbosity)
 	if !utils.CheckErrorWithMsg(err, "Failed to create kubelet service!\n") {
 		return err
 	}

--- a/scripts/cluster/setup_worker_kubelet.go
+++ b/scripts/cluster/setup_worker_kubelet.go
@@ -46,15 +46,13 @@ func SetupWorkerKubelet(stockContainerd string) error {
 func CreateWorkerKubeletService(criSock string) error {
 	utils.WaitPrintf("Creating kubelet service")
 	// Create service directory if not exist
-	_, err := utils.ExecShellCmd("sudo mkdir -p /usr/lib/systemd/system/kubelet.service.d")
+	_, err := utils.ExecShellCmd("sudo mkdir -p /etc/sysconfig")
 	if !utils.CheckErrorWithMsg(err, "Failed to create kubelet service!\n") {
 		return err
 	}
-	bashCmd := "sudo sh -c 'cat <<EOF > /usr/lib/systemd/system/kubelet.service.d/0-containerd.conf\n" +
-		"[Service]\n" +
-		`Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --v=%d --runtime-request-timeout=15m --container-runtime-endpoint=unix://%s"` +
-		"\nEOF'"
-
+	bashCmd := `sudo sh -c 'cat <<EOF > /etc/sysconfig/kubelet
+KUBELET_EXTRA_ARGS="--container-runtime=remote --v=%d --runtime-request-timeout=15m --container-runtime-endpoint=unix://%s"
+EOF'`
 	_, err = utils.ExecShellCmd(bashCmd, configs.System.LogVerbosity, criSock)
 	if !utils.CheckErrorWithMsg(err, "Failed to create kubelet service!\n") {
 		return err

--- a/scripts/setup/setup.go
+++ b/scripts/setup/setup.go
@@ -88,7 +88,7 @@ func SetupFirecrackerContainerd() error {
 	if !utils.CheckErrorWithMsg(err, "Failed to download kernel image!\n") {
 		return err
 	}
-	err = utils.CopyToDir(kernelImgPath, "/var/lib/firecracker-containerd/runtime/", true)
+	err = utils.CopyToDir(kernelImgPath, "/var/lib/firecracker-containerd/runtime/hello-vmlinux.bin", true)
 	if !utils.CheckErrorWithMsg(err, "Failed to copy kernel image!\n") {
 		return err
 	}


### PR DESCRIPTION
Fixes #931 **Error while deploying firecracker single-node deployment**
This issue is caused when migrating from bash script to go script. Did not change name properly.
https://github.com/vhive-serverless/vHive/blob/14f0b2d7ca9ab2a243063335c996e79d70349c5a/scripts/setup/setup.go#L91

---

Fixes #694 **required key GUEST_ADDR missing value**
This issue is caused by k8s version upgrade. After upgrade, they no longer support how we used to configure k8s before. This also fixes #899
https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/kubelet-integration/#the-kubelet-drop-in-file-for-systemd
https://github.com/kubernetes/release/issues/3392