### PR TITLE
Add troubleshooting step and fix for metallb setup timeout

### DIFF
--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -220,6 +220,15 @@ Another option is to install using official instructions: [https://golang.org/do
     > * The Kubelet was informed of the new secure connection details.
     > ```
 
+    > **Note:**
+    > 
+    > In case of failure
+    > ```
+    > error execution phase preflight: couldn't validate the identity of the API Server: Get "https://10.0.0.1:6443/api/v1/namespaces/kube-public/configmaps/cluster-info?timeout=10s": dial tcp 10.0.0.1:6443: connect: connection refused
+    > ```
+    > 
+    > Check the configuration of the firewall and make sure that traffic for the port `6443` is allowed.
+
 ### 5. Finalise Master Node
 **On the master node**, execute the following instructions below **as a non-root user with sudo rights** using **bash**:
 

--- a/scripts/cluster/setup_master_node.go
+++ b/scripts/cluster/setup_master_node.go
@@ -116,6 +116,14 @@ func InstallCalico() error {
 	if !utils.CheckErrorWithTagAndMsg(err, "Failed to install pod network!\n") {
 		return err
 	}
+
+	utils.WaitPrintf("Waiting for all nodes to be ready")
+	_, err = utils.ExecShellCmd("kubectl wait --for=condition=Ready nodes --all --timeout=600s")
+	if !utils.CheckErrorWithTagAndMsg(err, "Failed to wait for all nodes to be ready!\n") {
+		return err
+	}
+	utils.SuccessPrintf("All nodes are ready!\n")
+
 	return nil
 }
 
@@ -130,7 +138,7 @@ func InstallMetalLB() error {
 	if !utils.CheckErrorWithMsg(err, "Failed to install and configure MetalLB!\n") {
 		return err
 	}
-	_, err = utils.ExecShellCmd("kubectl -n metallb-system wait deploy controller --timeout=180s --for=condition=Available")
+	_, err = utils.ExecShellCmd("kubectl -n metallb-system wait deploy controller --timeout=600s --for=condition=Available")
 	if !utils.CheckErrorWithMsg(err, "Failed to install and configure MetalLB!\n") {
 		return err
 	}


### PR DESCRIPTION
## Summary

Add networking problem troubleshooting step: firewall configuration to accept traffic on 6443 port.

Add wait for node status to reduce the possibility of timeouts during metallb installation.

Both are problems encountered in #924.

## Implementation Notes :hammer_and_pick:

* Wait for the state of the nodes after installation of CNI (calico in our case)

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
