### PR TITLE
Fix runner issue

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,6 +47,11 @@ jobs:
         sudo apt update
         sudo apt install git -y
 
+    - name: Add rsync
+      run: |
+        sudo apt update
+        sudo apt install rsync -y
+  
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
       with:
@@ -68,7 +73,7 @@ jobs:
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
-        name: ctrd-logs
+        name: ctrd-logs-${{ matrix.test-name }}
         path: |
           /tmp/ctrd-logs/
           ${{ github.workspace }}/*.log

--- a/configs/knative_workloads/firecracker/helloworld.yaml
+++ b/configs/knative_workloads/firecracker/helloworld.yaml
@@ -1,0 +1,17 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - image: crccheck/hello-world:latest # Stub image. See https://github.com/vhive-serverless/vhive/issues/68
+          ports:
+            - name: h2c # For GRPC support
+              containerPort: 50051
+          env:
+            - name: GUEST_PORT # Port on which the firecracker-containerd container is accepting requests
+              value: "50051"
+            - name: GUEST_IMAGE # Container image to use for firecracker-containerd container
+              value: "ghcr.io/ease-lab/helloworld:var_workload"

--- a/configs/knative_workloads/firecracker/helloworldSerial.yaml
+++ b/configs/knative_workloads/firecracker/helloworldSerial.yaml
@@ -1,0 +1,18 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: default
+spec:
+  template:
+    spec:
+      containerConcurrency: 1
+      containers:
+        - image: crccheck/hello-world:latest # Stub image. See https://github.com/vhive-serverless/vhive/issues/68
+          ports:
+            - name: h2c # For GRPC support
+              containerPort: 50051
+          env:
+            - name: GUEST_PORT # Port on which the firecracker-containerd container is accepting requests
+              value: "50051"
+            - name: GUEST_IMAGE # Container image to use for firecracker-containerd container
+              value: "ghcr.io/ease-lab/helloworld:var_workload"

--- a/configs/knative_workloads/firecracker/helloworld_local.yaml
+++ b/configs/knative_workloads/firecracker/helloworld_local.yaml
@@ -1,0 +1,17 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - image: crccheck/hello-world:latest # Stub image. See https://github.com/vhive-serverless/vhive/issues/68
+          ports:
+            - name: h2c # For GRPC support
+              containerPort: 50051
+          env:
+            - name: GUEST_PORT # Port on which the firecracker-containerd container is accepting requests
+              value: "50051"
+            - name: GUEST_IMAGE # Container image to use for firecracker-containerd container
+              value: "docker-registry.registry.svc.cluster.local:5000/vhiveease/helloworld:var_workload"

--- a/configs/knative_workloads/firecracker/pyaes.yaml
+++ b/configs/knative_workloads/firecracker/pyaes.yaml
@@ -1,0 +1,17 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - image: crccheck/hello-world:latest # Stub image. See https://github.com/vhive-serverless/vhive/issues/68
+          ports:
+            - name: h2c # For GRPC support
+              containerPort: 50051
+          env:
+            - name: GUEST_PORT # Port on which the firecracker-containerd container is accepting requests
+              value: "50051"
+            - name: GUEST_IMAGE # Container image to use for firecracker-containerd container
+              value: "ghcr.io/ease-lab/pyaes:var_workload"

--- a/configs/knative_workloads/gvisor/helloworld.yaml
+++ b/configs/knative_workloads/gvisor/helloworld.yaml
@@ -1,0 +1,17 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/ease-lab/helloworld:var_workload
+          ports:
+            - name: h2c # For GRPC support
+              containerPort: 50051
+          env:
+            - name: GUEST_PORT # Port on which the firecracker-containerd container is accepting requests
+              value: "50051"
+            - name: GUEST_IMAGE # Container image to use for firecracker-containerd container
+              value: "ghcr.io/ease-lab/helloworld:var_workload"

--- a/configs/knative_workloads/gvisor/helloworldSerial.yaml
+++ b/configs/knative_workloads/gvisor/helloworldSerial.yaml
@@ -1,0 +1,18 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: default
+spec:
+  template:
+    spec:
+      containerConcurrency: 1
+      containers:
+        - image: ghcr.io/ease-lab/helloworld:var_workload
+          ports:
+            - name: h2c # For GRPC support
+              containerPort: 50051
+          env:
+            - name: GUEST_PORT # Port on which the firecracker-containerd container is accepting requests
+              value: "50051"
+            - name: GUEST_IMAGE # Container image to use for firecracker-containerd container
+              value: "ghcr.io/ease-lab/helloworld:var_workload"

--- a/configs/knative_workloads/gvisor/pyaes.yaml
+++ b/configs/knative_workloads/gvisor/pyaes.yaml
@@ -1,0 +1,17 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - image: ghcr.io/ease-lab/pyaes:var_workload
+          ports:
+            - name: h2c # For GRPC support
+              containerPort: 50051
+          env:
+            - name: GUEST_PORT # Port on which the firecracker-containerd container is accepting requests
+              value: "50051"
+            - name: GUEST_IMAGE # Container image to use for firecracker-containerd container
+              value: "ghcr.io/ease-lab/pyaes:var_workload"

--- a/scripts/github_runner/conf.json
+++ b/scripts/github_runner/conf.json
@@ -1,20 +1,24 @@
 {
   "ghOrg": "<GitHub account>",
+  "ghBranch": "<GitHub branch>",
   "ghPat": "<GitHub PAT>",
-  "hostUsername": "ubuntu",
+  "hostUsername": "root",
   "runners": {
-    "pc91.cloudlab.umass.edu": {
+    "10.96.190.31": {
       "type": "cri",
       "sandbox": "firecracker"
     },
-    "pc101.cloudlab.umass.edu": {
+    "10.96.190.176": {
       "type": "cri",
-      "sandbox": "gvisor",
-      "restart": true
+      "sandbox": "gvisor"
     },
-    "pc72.cloudlab.umass.edu": {
+    "10.96.190.94": {
       "type": "integ",
-      "num": 2
+      "num": 2,
+      "restart": false
+    },
+    "10.96.190.53": {
+        "type": "profile"
     }
   }
 }

--- a/scripts/github_runner/setup_bare_metal_runner.sh
+++ b/scripts/github_runner/setup_bare_metal_runner.sh
@@ -45,9 +45,12 @@ else
   echo "No service file, no need to clean"
 fi
 
-
 VHIVE_ROOT="$(git rev-parse --show-toplevel)"
-"$VHIVE_ROOT"/scripts/cloudlab/setup_node.sh "$SANDBOX"
+SCRIPTS=$VHIVE_ROOT/scripts
+
+source $SCRIPTS/install_go.sh
+pushd $SCRIPTS && go build -o setup_tool && popd
+$SCRIPTS/setup_tool setup_node "$SANDBOX"
 
 cd
 export RUNNER_ALLOW_RUNASROOT=1
@@ -58,4 +61,3 @@ RUNNER_LABEL=$SANDBOX-cri
 curl -s https://raw.githubusercontent.com/actions/runner/main/scripts/create-latest-svc.sh | bash -s - -s "$GH_ORG"/vhive -n "$RUNNER_NAME" -l "$RUNNER_LABEL" -f
 
 echo "0 4 * * * root reboot" | sudo tee -a /etc/crontab
-

--- a/scripts/github_runner/setup_cri_test_env.sh
+++ b/scripts/github_runner/setup_cri_test_env.sh
@@ -45,11 +45,7 @@ $VHIVE_ROOT/scripts/setup_tool -vhive-repo-dir $VHIVE_ROOT setup_zipkin
 # FIXME (gh-709)
 #source etc/profile && go run $VHIVE_ROOT/examples/registry/populate_registry.go -imageFile $VHIVE_ROOT/examples/registry/images.txt
 
-sudo KUBECONFIG=/etc/kubernetes/admin.conf kn service apply helloworld -f $VHIVE_ROOT/configs/knative_workloads/helloworld.yaml
-# FIXME (gh-709)
-#KUBECONFIG=/etc/kubernetes/admin.conf sudo kn service apply helloworldlocal -f $VHIVE_ROOT/configs/knative_workloads/helloworld_local.yaml
-#                                      ^^^^^^^ This WILL NOT work because ${KUBECONFIG} would not be set in the context when executing `kn`
-
-sudo KUBECONFIG=/etc/kubernetes/admin.conf kn service apply helloworldserial -f $VHIVE_ROOT/configs/knative_workloads/helloworldSerial.yaml
-sudo KUBECONFIG=/etc/kubernetes/admin.conf kn service apply pyaes -f $VHIVE_ROOT/configs/knative_workloads/pyaes.yaml
+sudo KUBECONFIG=/etc/kubernetes/admin.conf kn service apply helloworld -f $VHIVE_ROOT/configs/knative_workloads/$SANDBOX/helloworld.yaml
+sudo KUBECONFIG=/etc/kubernetes/admin.conf kn service apply helloworldserial -f $VHIVE_ROOT/configs/knative_workloads/$SANDBOX/helloworldSerial.yaml
+sudo KUBECONFIG=/etc/kubernetes/admin.conf kn service apply pyaes -f $VHIVE_ROOT/configs/knative_workloads/$SANDBOX/pyaes.yaml
 sleep 30s


### PR DESCRIPTION
Fix #947 and other runner related issues
- Remove deprecated node setup script written in bash and migrate to go script
- Fix integration tests not working due to some missing packages and log name collision
- Make gVisor cri test to use proper yaml file: stub does not work with gVisor
- Let runner use specific branch to test runner upgrades