### PR TITLE
add power manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for [`OpenYurt`](https://openyurt.io/), an open platform that extends upstream Kubernetes to run on edge node pools. More details on how to the `Knative-atop-OpenYurt` mode are described [here](scripts/openyurt-deployer/README.md).
 - Added support for arm64 ubuntu 18.04 in stock-only setup with [setup scripts](./scripts/setup.go).
+- Added support for [`K8 Power Manager`](https://networkbuilders.intel.com/solutionslibrary/power-manager-a-kubernetes-power-operator-technology-guide), a Kubernetes operator designed to manage and optimize power consumption in a Kubernetes cluster. More details are described [here](docs/power_manager.md).
 
 
 ### Changed

--- a/docs/power_manager.md
+++ b/docs/power_manager.md
@@ -1,0 +1,26 @@
+# K8s Power Manager
+
+## Components
+1. **Power Manager Controller**: ensures the actual state matches the desired state of the cluster.
+2. **Power Config Controller**: sees the power config created by user and deploys Power Node Agents onto each node specified using a daemon set.
+    - power node selector: A key/value map used to define a list of node labels that a node must satisfy for the operator's node
+      agent to be deployed.
+    - power profiles: The list of power profiles that the user wants available on the nodes
+3. **Power Node Agent**: containerized applications used to communicate with the node's Kubelet pod resources endpoint to discover the exact CPUs that
+   are allocated per container and tune frequency of the cores as requested
+
+4. **Power Profile**: predefined configuration that specifies how the system should manage power consumption for various components such as CPUs. It includes settings applied to host level such as CPU frequency, governor etc.
+
+4. **Power Workload**: the object used to define the lists of CPUs configured with a particular Power Profile. A power workload is created for each Power Profile on each Node with the Power Node Agent deployed. A power workload is represented in the Intel Power Optimization Library by a Pool. The Pools hold the values of the Power Profile used, their frequencies, and the CPUs that need to be configured. The creation of the Pool – and any additions to the Pool – then 
+carries out the changes.
+
+## Setup 
+Execute the following below **as a non-root user with sudo rights** using **bash**:
+1. Follow [a quick-start guide](quickstart_guide.md) to set up a Knative cluster.
+2. On master node, export NODE_NAME to your node name and run K8s power manager set up script:
+  ```bash
+    export NODE_NAME= *Name of the node you want to apply shared profile on*
+    ./scripts/power_manager/setup_power_manager.sh;
+  ```
+
+  This will install and configure the Kubernetes Power Manager for managing power consumption in a Kubernetes cluster. It clones the Power Manager repository, sets up the necessary namespace, service account, and Role-based Access Control rule, then generates and installs custom resource definitions, and deploys the Power Manager controller. It also applies a Power config to manage the power node agents, a shared profile for specifying CPU frequencies, and a shared workload for applying the CPU tuning settings. 

--- a/go.work
+++ b/go.work
@@ -5,4 +5,5 @@ use (
 	./scripts
 	./scripts/github_runner
 	./scripts/openyurt-deployer
+	./power_manager
 )

--- a/go.work.sum
+++ b/go.work.sum
@@ -76,6 +76,7 @@ github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.2.1/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-openapi/analysis v0.21.2/go.mod h1:HZwRk4RRisyG8vx2Oe6aqeSQcoxRp47Xkp3+K6q+LdY=

--- a/power_manager/go.mod
+++ b/power_manager/go.mod
@@ -1,0 +1,3 @@
+module github.com/vhive-serverless/vhive/power_manager
+
+go 1.21

--- a/power_manager/util.go
+++ b/power_manager/util.go
@@ -1,0 +1,35 @@
+package power_manager
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func SetPowerProfileToNode(powerprofileName string, nodeName string, minFreq int64, maxFreq int64) error {
+	// powerConfig
+	command := fmt.Sprintf("kubectl apply -f - <<EOF\napiVersion: \"power.intel.com/v1\"\nkind: PowerConfig\nmetadata:\n  name: power-config\n  namespace: intel-power\nspec:\n powerNodeSelector:\n     kubernetes.io/os: linux\n powerProfiles:\n    - \"performance\"\nEOF")
+	cmd := exec.Command("bash", "-c", command)
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	// performanceProfile w freq
+	command = fmt.Sprintf("kubectl apply -f - <<EOF\napiVersion: \"power.intel.com/v1\"\nkind: PowerProfile\nmetadata:\n  name: %s\n  namespace: intel-power\nspec:\n  name: \"%s\"\n  max: %d\n  min: %d\n  shared: true\n  governor: \"performance\"\nEOF", powerprofileName, powerprofileName, minFreq, maxFreq)
+	cmd = exec.Command("bash", "-c", command)
+
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	// apply to node
+	command = fmt.Sprintf("kubectl apply -f - <<EOF\napiVersion: \"power.intel.com/v1\"\nkind: PowerWorkload\nmetadata:\n  name: %s-%s-workload\n  namespace: intel-power\nspec:\n  name: \"%s-%s-workload\"\n  allCores: true\n  powerNodeSelector:\n    kubernetes.io/hostname: %s\n  powerProfile: \"%s\"\nEOF", powerprofileName, nodeName, powerprofileName, nodeName, nodeName, powerprofileName)
+	cmd = exec.Command("bash", "-c", command)
+
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/scripts/power_manager/power_config.yaml
+++ b/scripts/power_manager/power_config.yaml
@@ -1,0 +1,12 @@
+apiVersion: "power.intel.com/v1"
+kind: PowerConfig
+metadata:
+  name: power-config
+  namespace: intel-power
+spec:
+  # Add labels here for the Nodes you want the PowerNodeAgent to be applied to
+  powerNodeSelector:
+    kubernetes.io/os: linux
+  # Add wanted PowerProfiles here; valid entries are as follows: performance, balance-performance, balance-power
+  powerProfiles:
+    - "performance"

--- a/scripts/power_manager/setup_power_manager.sh
+++ b/scripts/power_manager/setup_power_manager.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# MIT License
+#
+# Copyright (c) 2024 Eang Sokunthea
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Install K8 Power Manager
+git clone https://github.com/intel/kubernetes-power-manager $HOME/kubernetes-power-manager
+
+# Set up the necessary Namespace, Service Account, and RBAC rules for the Kubernetes Power Manager
+kubectl apply -f $HOME/kubernetes-power-manager/config/rbac/namespace.yaml
+kubectl apply -f $HOME/kubernetes-power-manager/config/rbac/rbac.yaml
+
+# Generate the CRD templates, create the Custom Resource Definitions, and install the CRDs and Built Docker images locally
+cd $HOME/kubernetes-power-manager
+make
+
+# Apply Power Manager Controller
+kubectl apply -f $HOME/kubernetes-power-manager/config/manager/manager.yaml
+
+# Apply PowerConfig -> create the power-node-agent DaemonSet that manages the Power Node Agent pods.
+kubectl apply -f $HOME/vhive/scripts/power_manager/power_config.yaml
+
+# Apply Profile. U can modify the spec in the shared-profile.yaml file
+kubectl apply -f $HOME/vhive/scripts/power_manager/shared-profile.yaml
+
+# Apply the shared PowerWorkload. All CPUs (except reservedCPUs specified in this yaml file) will be tuned to the specified frequency in shared-profile.yaml
+envsubst < $HOME/vhive/scripts/power_manager/shared-workload.yaml | kubectl apply -f -
+
+kubectl get powerprofiles -n intel-power
+kubectl get powerworkloads -n intel-power

--- a/scripts/power_manager/shared-profile.yaml
+++ b/scripts/power_manager/shared-profile.yaml
@@ -1,0 +1,11 @@
+apiVersion: power.intel.com/v1
+kind: PowerProfile
+metadata:
+  name: performance
+  namespace: intel-power
+spec:
+  name: "performance"
+  max: 1200
+  min: 1200
+  shared: true 
+  governor: "performance"

--- a/scripts/power_manager/shared-workload.yaml
+++ b/scripts/power_manager/shared-workload.yaml
@@ -1,0 +1,13 @@
+apiVersion: "power.intel.com/v1"
+kind: PowerWorkload
+metadata:
+  name: performance-$NODE_NAME-workload
+  namespace: intel-power
+spec:
+  name: "performance-$NODE_NAME-workload"
+  allCores: true
+  powerNodeSelector:
+    # The label must be as below, as this workload will be specific to the Node
+    kubernetes.io/hostname: $NODE_NAME
+  # Replace this value with the intended shared PowerProfile
+  powerProfile: "performance"


### PR DESCRIPTION
## Summary

This PR uses k8 Power Manager to tune CPU frequency and run experiments (workload sensitivity and internode scaling) to investigate how tuning frequencies can help to optimise power consumption in serverless computing
## Implementation Notes :hammer_and_pick:

set up K8 power manager (power profiles, power workloads)
run the experiments using sleeping, spinning, auth, aes benchmarks from vSwarm

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
