### PR TITLE
Change IPs from external to local

### DIFF
--- a/cri/cri_test.go
+++ b/cri/cri_test.go
@@ -162,7 +162,7 @@ func invoke(t *testing.T, functionURL string) {
 	client, conn, err := getClient(functionURL)
 	require.NoError(t, err, "Failed to dial function URL")
 	defer conn.Close()
-	ctxFwd, cancel := context.WithDeadline(context.Background(), time.Now().Add(20*time.Second))
+	ctxFwd, cancel := context.WithDeadline(context.Background(), time.Now().Add(60*time.Second))
 	defer cancel()
 
 	resp, err := client.SayHello(ctxFwd, &hpb.HelloRequest{Name: reqPayload})

--- a/scripts/cluster/setup_worker_kubelet.go
+++ b/scripts/cluster/setup_worker_kubelet.go
@@ -50,10 +50,11 @@ func CreateWorkerKubeletService(criSock string) error {
 	if !utils.CheckErrorWithMsg(err, "Failed to create kubelet service!\n") {
 		return err
 	}
+	nodeIP, _ := utils.GetNodeIP()
 	bashCmd := `sudo sh -c 'cat <<EOF > /etc/default/kubelet
-KUBELET_EXTRA_ARGS="--v=%d --runtime-request-timeout=15m --container-runtime-endpoint=unix://%s"
+KUBELET_EXTRA_ARGS="--v=%d --runtime-request-timeout=15m --container-runtime-endpoint=unix://%s --node-ip %s"
 EOF'`
-	_, err = utils.ExecShellCmd(bashCmd, configs.System.LogVerbosity, criSock)
+	_, err = utils.ExecShellCmd(bashCmd, configs.System.LogVerbosity, criSock, nodeIP)
 	if !utils.CheckErrorWithMsg(err, "Failed to create kubelet service!\n") {
 		return err
 	}

--- a/scripts/setup.go
+++ b/scripts/setup.go
@@ -250,7 +250,7 @@ func main() {
 	}
 
 	if err != nil {
-		utils.FatalPrintf("Faild subcommand: %s!\n", subCmd)
+		utils.FatalPrintf("Failed subcommand: %s!\n", subCmd)
 		utils.CleanEnvironment()
 		os.Exit(1)
 	}

--- a/scripts/utils/utils.go
+++ b/scripts/utils/utils.go
@@ -171,3 +171,20 @@ func InstallYQ() {
 	_, err := ExecShellCmd(`sudo wget %s -O /usr/bin/yq && sudo chmod +x /usr/bin/yq`, yqUrl)
 	CheckErrorWithTagAndMsg(err, "Failed to add yq!\n")
 }
+
+func GetNodeIP() (string, error) {
+	nodeIP, err := ExecShellCmd(`ip route | awk '{print $(NF)}' | awk '/^10\..*/'`)
+	if err == nil {
+		return nodeIP, nil
+	}
+
+	WarnPrintf("Failed to find IP address in 10.0.0.0/8 subnet! Falling back to one of the host IP addresses\n")
+	nodeIP, err = ExecShellCmd(`hostname -I | awk '{print $1}'`)
+
+	if err != nil {
+		ErrorPrintf("Failed to find host IP address!\n")
+		return "", err
+	}
+
+	return nodeIP, nil
+}


### PR DESCRIPTION
## Summary

Change the IPs of k8s nodes to the experimental subnet instead of the default (which is control in CloudLab).

## Implementation Notes :hammer_and_pick:

* Add the argument for kubelet to use a specific IP from the internal subnet.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
