### PR TITLE
Downgrade Go to version 1.21.1

### DIFF
--- a/.github/workflows/build_setup.yml
+++ b/.github/workflows/build_setup.yml
@@ -22,10 +22,10 @@ jobs:
         name: Build setup scripts
         runs-on: ubuntu-20.04
         steps:
-        - name: Set up Go 1.22
+        - name: Set up Go 1.21
           uses: actions/setup-go@v5
           with:
-            go-version: '1.22'
+            go-version: '1.21'
         
         - name: Check out the code
           uses: actions/checkout@v4

--- a/.github/workflows/cri_minio_test.yml
+++ b/.github/workflows/cri_minio_test.yml
@@ -34,10 +34,10 @@ jobs:
     - name: Setup TMPDIR
       run: mkdir -p $TMPDIR
 
-    - name: Set up Go 1.22
+    - name: Set up Go 1.21
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/.github/workflows/cri_stock_containerd_test.yml
+++ b/.github/workflows/cri_stock_containerd_test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
 
     - name: Build setup scripts
       run: pushd scripts && go build -o setup_tool && popd

--- a/.github/workflows/cri_tests.yml
+++ b/.github/workflows/cri_tests.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ${{ fromJSON(format('["self-hosted", "{0}-cri"]', inputs.sandbox)) }}
 
     steps:
-
       - name: Host Info
         run: |
           echo $HOSTNAME
@@ -31,8 +30,8 @@ jobs:
       - name: Set up golang
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
-          
+          go-version: "1.21"
+
       - name: Add rsync
         run: |
           sudo apt update

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,10 +31,10 @@ jobs:
         test-name: [test, test-man-bench]
     steps:
 
-    - name: Set up Go 1.22
+    - name: Set up Go 1.21
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
 
     - name: Set up Python 3.x
       uses: actions/setup-python@v5

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -20,10 +20,10 @@ jobs:
     - name: Setup TMPDIR
       run: mkdir -p $TMPDIR
 
-    - name: Set up Go 1.22
+    - name: Set up Go 1.21
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
 
     - name: Upgrade git
       run: |
@@ -77,10 +77,10 @@ jobs:
     - name: Setup TMPDIR
       run: mkdir -p $TMPDIR
 
-    - name: Set up Go 1.22
+    - name: Set up Go 1.21
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/.github/workflows/openyurt-unit-test.yml
+++ b/.github/workflows/openyurt-unit-test.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Go 1.22
+    - name: Set up Go 1.21
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
 
     - name: Check out the code
       uses: actions/checkout@v4

--- a/.github/workflows/stargz_tests.yml
+++ b/.github/workflows/stargz_tests.yml
@@ -42,10 +42,10 @@ jobs:
       - name: Checkout LFS objects
         run: git lfs checkout
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.21
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.21'
 
       - name: Build setup scripts
         run: pushd scripts && go build -o setup_tool && popd

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,10 +29,10 @@ jobs:
         module: [misc, networking, snapshotting]
     steps:
 
-    - name: Set up Go 1.22
+    - name: Set up Go 1.21
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
         
     - name: Set up Python 3.x
       uses: actions/setup-python@v5
@@ -74,10 +74,10 @@ jobs:
         module: [profile]
     steps:
 
-    - name: Set up Go 1.22
+    - name: Set up Go 1.21
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
         
     - name: Set up Python 3.x
       uses: actions/setup-python@v5
@@ -122,10 +122,10 @@ jobs:
         module: [ ctriface, ctriface/image, devmapper ]
     steps:
     
-    - name: Set up Go 1.22
+    - name: Set up Go 1.21
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.21'
 
     - name: Upgrade git
       run: |

--- a/configs/setup/system.json
+++ b/configs/setup/system.json
@@ -1,5 +1,5 @@
 {
-	"GoVersion": "1.22.0",
+	"GoVersion": "1.21.9",
 	"GoDownloadUrlTemplate": "https://go.dev/dl/go%s.linux-%s.tar.gz",
 	"ContainerdVersion": "1.6.18",
 	"ContainerdDownloadUrlTemplate": "https://github.com/containerd/containerd/releases/download/v%s/containerd-%s-linux-%s.tar.gz",

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -45,7 +45,7 @@ SSD-equipped nodes are highly recommended. Full list of CloudLab nodes can be fo
 
 ### 4. Go Installation
 
-If you intend to build the setup scripts from source, you need to install go by running: (This will install version `1.22.0`. You can configure the version to install in `configs/setup/system.json` as `GoVersion`)
+If you intend to build the setup scripts from source, you need to install go by running: (This will install version `1.21.1`. You can configure the version to install in `configs/setup/system.json` as `GoVersion`)
 ```bash
 ./scripts/install_go.sh; source /etc/profile
 ```


### PR DESCRIPTION
## Summary

Downgrade GO version from 1.22.0 to 1.21.1

## Implementation Notes :hammer_and_pick:

* Update `GoVersion` in ` configs/setup/system.json`
* Modify Github actions workflow

## External Dependencies :four_leaf_clover:

* NA

## Breaking API Changes :warning:

* NA

*Simply specify none (N/A) if not applicable.*
