### PR TITLE
Support Kubernetes and Knative cluster setup for arm devices

### DIFF
--- a/configs/registry/repository-update-hosts.yaml
+++ b/configs/registry/repository-update-hosts.yaml
@@ -43,7 +43,7 @@ spec:
           echo "Done."
       containers:
       - name: init-container-did-the-work
-        image: gcr.io/google_containers/pause-amd64:3.1@sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610
+        image: gcr.io/google_containers/pause:3.1@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea
       terminationGracePeriodSeconds: 30
       volumes:
       - name: etchosts

--- a/configs/setup/kube.json
+++ b/configs/setup/kube.json
@@ -6,5 +6,5 @@
 	"ApiserverPort": "6443",
 	"ApiserverToken": "",
 	"ApiserverTokenHash": "",
-	"CalicoVersion": "3.27.2"
+	"CalicoVersion": "3.27.3"
 }

--- a/configs/setup/system.json
+++ b/configs/setup/system.json
@@ -14,7 +14,7 @@
 	"KubeRepoUrl": "https://pkgs.k8s.io/core:/stable:/v1.29/deb/",
 	"PmuToolsRepoUrl": "https://github.com/vhive-serverless/pmu-tools",
 	"ProtocVersion": "3.19.4",
-	"ProtocDownloadUrlTemplate": "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-linux-x86_64.zip",
+	"ProtocDownloadUrlTemplate": "https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-linux-%s.zip",
 	"LogVerbosity": 0,
 	"YQDownloadUrlTemplate": "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_%s"
 }

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -7,7 +7,7 @@ To see how to setup a single node cluster with stock-only or gVisor, see [Develo
 ## I. Host platform requirements
 ### 1. Hardware
 1. Two x64 servers in the same network.
-    - We have not tried vHive with Arm but it may not be hard to port because Firecracker supports Arm64 ISA.
+    - vHive is now compatible with arm64 Ubuntu 18.04 servers for multi-node clusters using the `stock-only` setting. Other configurations and OS versions have not been tested at this time.
 2. Hardware support for virtualization and KVM.
     - Nested virtualization is supported provided that KVM is available.
 3. The root partition of the host filesystem should be mounted on an **SSD**. That is critical for snapshot-based cold-starts.

--- a/scripts/configs/system.go
+++ b/scripts/configs/system.go
@@ -64,7 +64,15 @@ var System = SystemEnvironmentStruct{
 }
 
 func (system *SystemEnvironmentStruct) GetProtocDownloadUrl() string {
-	return fmt.Sprintf(system.ProtocDownloadUrlTemplate, system.ProtocVersion, system.ProtocVersion)
+	unameArch := system.CurrentArch
+	switch unameArch {
+	case "amd64":
+		unameArch = "x86_64"
+	case "arm64":
+		unameArch = "aarch_64"
+	default:
+	}
+	return fmt.Sprintf(system.ProtocDownloadUrlTemplate, system.ProtocVersion, system.ProtocVersion, unameArch)
 }
 
 func (system *SystemEnvironmentStruct) GetContainerdDownloadUrl() string {
@@ -80,6 +88,8 @@ func (system *SystemEnvironmentStruct) GetRunscDownloadUrl() string {
 	switch unameArch {
 	case "amd64":
 		unameArch = "x86_64"
+	case "arm64":
+		unameArch = "aarch_64"
 	default:
 	}
 

--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -32,6 +32,9 @@ case $arch in
   'x86_64')
     arch='amd64'
     ;;
+  'aarch64')
+    arch='arm64'
+    ;;
   *)
     echo "Unsupported architecture $arch"
     exit 1

--- a/scripts/utils/system.go
+++ b/scripts/utils/system.go
@@ -92,7 +92,7 @@ func ExecShellCmd(cmd string, pars ...any) (string, error) {
 // Detect current architecture
 func DetectArch() error {
 	switch configs.System.CurrentArch {
-	case "amd64":
+	case "amd64", "arm64":
 	default:
 		// Only amd64(x86_64) are supported at present
 		FatalPrintf("Unsupported architecture: %s\n", configs.System.CurrentArch)

--- a/scripts/utils/utils.go
+++ b/scripts/utils/utils.go
@@ -166,8 +166,8 @@ func TurnOffAutomaticUpgrade() error {
 }
 
 func InstallYQ() {
-	InfoPrintf("Downloading yq for yaml parsing of template")
+	WaitPrintf("Downloading yq for yaml parsing of template")
 	yqUrl := fmt.Sprintf(configs.System.YqDownloadUrlTemplate, configs.System.CurrentArch)
 	_, err := ExecShellCmd(`sudo wget %s -O /usr/bin/yq && sudo chmod +x /usr/bin/yq`, yqUrl)
-	CheckErrorWithMsg(err, "Failed to add yq!\n")
+	CheckErrorWithTagAndMsg(err, "Failed to add yq!\n")
 }


### PR DESCRIPTION
## Summary

Support `stock-only` k8s and knative cluster setup for arm64/amd64 ubuntu 18.04 devices.
 
## Implementation Notes :hammer_and_pick:

* Removed restrictions in setup scripts for arm architecture 
* Edit installation paths to support arm devices

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A