### PR TITLE
create prepare_one_node_cluster command

### DIFF
--- a/scripts/cloudlab/start_onenode_vhive_cluster.go
+++ b/scripts/cloudlab/start_onenode_vhive_cluster.go
@@ -122,6 +122,10 @@ func StartOnenodeVhiveCluster(sandbox string) error {
 		return err
 	}
 
+	if err = cluster.SetupMasterNode(sandbox); err != nil {
+		return err
+	}
+
 	utils.InfoPrintf("All logs are stored in %s", ctrdLogDir)
 	return nil
 }

--- a/scripts/cluster/create_one_node_cluster.go
+++ b/scripts/cluster/create_one_node_cluster.go
@@ -70,11 +70,6 @@ func CreateOneNodeCluster(stockContainerd string) error {
 		return err
 	}
 
-	err = SetupMasterNode(stockContainerd)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/scripts/setup.go
+++ b/scripts/setup.go
@@ -79,6 +79,7 @@ func main() {
 	availableCmds := []string{
 		"create_multinode_cluster",
 		"create_one_node_cluster",
+		"prepare_one_node_cluster",
 		"setup_master_node",
 		"setup_worker_kubelet",
 		"setup_node",
@@ -150,6 +151,18 @@ func main() {
 		utils.InfoPrintf("Create multinode cluster\n")
 		err = cluster.CreateMultinodeCluster(setupFlags.Args()[1])
 	case "create_one_node_cluster":
+		if setupFlags.NArg() < 2 {
+			utils.FatalPrintf("Missing parameters: %s <stock-containerd>\n", subCmd)
+			utils.CleanEnvironment()
+			os.Exit(1)
+		}
+		utils.InfoPrintf("Create one-node Cluster\n")
+		err = cluster.CreateOneNodeCluster(setupFlags.Args()[1])
+		if err == nil {
+			utils.InfoPrintf("Set up master node\n")
+			err = cluster.SetupMasterNode(setupFlags.Args()[1])
+		}
+	case "prepare_one_node_cluster":
 		if setupFlags.NArg() < 2 {
 			utils.FatalPrintf("Missing parameters: %s <stock-containerd>\n", subCmd)
 			utils.CleanEnvironment()


### PR DESCRIPTION
## Summary

To better support the deployment and management of single-node Kubernetes clusters, I have created a new command `prepare_one_node_cluster`. Previously, the `create_one_node_cluster` command was responsible for both preparing the single-node environment and setting up the master node. Now, I have added a new command called `prepare_one_node_cluster`. With this new command, users can first prepare the single-node environment, and then manually run `setup_master_node` to set up the master node when needed. This increased flexibility enables users to selectively execute the relevant steps based on their specific needs.

## Implementation Notes :hammer_and_pick:

First, I have split the `create_one_node_cluster` command into two parts: preparing the single-node environment and setting up the master node. Note that I have only divided the previous `create_one_node_cluster` command into two functions, without affecting the functionality of the original `create_one_node_cluster` command.

Subsequently, I have created the `prepare_one_node_cluster` command, which only runs the first part of the `create_one_node_cluster` command, i.e., the part responsible for preparing the single-node environment. After running the `prepare_one_node_cluster` command, users can manually call the `setup_master_node` command when they need to.

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

N/A
