### PR TITLE
Fix GetNodeIP to get the first ip

### DIFF
--- a/scripts/utils/utils.go
+++ b/scripts/utils/utils.go
@@ -174,8 +174,8 @@ func InstallYQ() {
 
 func GetNodeIP() (string, error) {
 	// Choose the first ip address starting from 10.
-	nodeIP, err := ExecShellCmd(`ip route | awk '{print $(NF)}' | awk '/^10\..*/ {print; exit}'`)
-	if err == nil {
+	nodeIP, err := ExecShellCmd(`ip route | awk '/ src / {for(i=1; i<=NF; i++) if ($i == "src") print $(i+1)}' | awk '/^10\..*/ {print; exit}'`)
+	if (nodeIP != "") && (err == nil) {
 		return nodeIP, nil
 	}
 

--- a/scripts/utils/utils.go
+++ b/scripts/utils/utils.go
@@ -173,7 +173,8 @@ func InstallYQ() {
 }
 
 func GetNodeIP() (string, error) {
-	nodeIP, err := ExecShellCmd(`ip route | awk '{print $(NF)}' | awk '/^10\..*/'`)
+	// Choose the first ip address starting from 10.
+	nodeIP, err := ExecShellCmd(`ip route | awk '{print $(NF)}' | awk '/^10\..*/ {print; exit}'`)
 	if err == nil {
 		return nodeIP, nil
 	}


### PR DESCRIPTION
## Summary

Change the bash command for getting node's private ip address
Now it would get the first ip address starting with 10.

## Implementation Notes :hammer_and_pick:

Change bash command implementation to:
```
ip route | awk '{print $(NF)}' | awk '/^10\..*/ {print; exit}'
```

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*
