### PR TITLE
Use node IP for inter pod routing

### DIFF
--- a/scripts/cluster/setup_master_node.go
+++ b/scripts/cluster/setup_master_node.go
@@ -123,7 +123,7 @@ func InstallCalico() error {
 
 	_, err = utils.ExecShellCmd(`yq -i '(select (.kind == "DaemonSet" and .metadata.name == "calico-node" and
 	.spec.template.spec.containers[].name == "calico-node") |
-	.spec.template.spec.containers[].env) += {"name": "IP_AUTODETECTION_METHOD", "value": "skip-interface=br.*"}' %s`,
+	.spec.template.spec.containers[].env) += {"name": "IP_AUTODETECTION_METHOD", "value": "kubernetes-internal-ip"}' %s`,
 		path.Join(configs.VHive.VHiveRepoPath, path.Join("configs/calico", "calico.yaml")))
 	if !utils.CheckErrorWithTagAndMsg(err, "Failed to patch Calico!\n") {
 		return err


### PR DESCRIPTION
## Summary

Misconfiguration of Calico was causing the inter-pod communication (including Knative-Istio communication) to be routed through control network if used on CloudLab clusters. This was causing high traffic on the control interface which is not advisable for CloudLab.

## Implementation Notes :hammer_and_pick:

* Change the configuration of Calico to use k8s node IP which are set to experiment network.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
