### PR TITLE
Bump Ubuntu version in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
 
     name: Build and check code quality
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   function_images:
     name: Build function docker images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +29,7 @@ jobs:
         DOCKER_BUILDKIT=1 docker build ./function-images/${{ matrix.image }}
   integ_test_image:
     name: Build integration test docker images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_setup.yml
+++ b/.github/workflows/build_setup.yml
@@ -20,7 +20,7 @@ env:
 jobs:
     build_setup:
         name: Build setup scripts
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         steps:
 
         - name: Check out the code

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Spellcheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: rojopolis/spellcheck-github-actions@0.47.0
@@ -17,7 +17,7 @@ jobs:
         config_path: configs/.spellcheck.yml
   commitlint:
     name: Commitlint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
           --verbose
   markdown-link-check:
     name: LinkCheck
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/skip_build.yml
+++ b/.github/workflows/skip_build.yml
@@ -20,6 +20,6 @@ env:
 jobs:
   build:
     name: Build and check code quality
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - run: 'echo "This check not required"'

--- a/.github/workflows/skip_build_setup.yml
+++ b/.github/workflows/skip_build_setup.yml
@@ -20,6 +20,6 @@ env:
 jobs:
   build_setup:
     name: Build setup scripts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - run: 'echo "This check not required"'

--- a/.github/workflows/skip_stargz_tests.yml
+++ b/.github/workflows/skip_stargz_tests.yml
@@ -22,6 +22,6 @@ env:
 jobs:
   stargz-container-test:
     name: Test running stargz-based image using kn
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - run: 'echo "This check not required"'

--- a/.github/workflows/skip_unit_tests.yml
+++ b/.github/workflows/skip_unit_tests.yml
@@ -22,18 +22,18 @@ env:
 jobs:
   unit-test:
     name: Unit test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - run: 'echo "This check not required"'
   
   profile-unit-test:
     name: "Unit test: profile unit test"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - run: 'echo "This check not required"'
 
   firecracker-containerd-interface-test:
     name: "Unit tests: Firecracker-containerd interface"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - run: 'echo "This check not required"'

--- a/.github/workflows/stargz_tests.yml
+++ b/.github/workflows/stargz_tests.yml
@@ -26,7 +26,7 @@ jobs:
       KIND_VERSION: v0.22.0
       K8S_VERSION: v1.29
       YAML_DIR: workloads/container
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   unit-test:
     name: Unit test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 
 ### Changed
 
+- Upgraded supported Ubuntu version to 24.04.
+- Bump Go to 1.22.
+
 ### Fixed
 
 - Fix IP choice for CloudLab clusters to use the internal network interface for control plane communication.
 - Fix disk issues on CloudLab profiles after restart.
-- Bump Go to 1.22.
 - Fix iptables issues on Ubuntu 22.04, 24.04.
+- Improved networking for Firecracker uVMs.
 
 ## Release v1.7.1
 

--- a/configs/.wordlist.txt
+++ b/configs/.wordlist.txt
@@ -537,6 +537,7 @@ ustiugov
 Ustiugov
 utils
 UUID
+uVMs
 vhive
 vHive
 vhiveease

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -34,9 +34,9 @@ The expected output should be:
 If the opened shell is not a "bash" one, you can just type "bash" in the terminal and it will change the current shell to "bash".
 
 #### A. CloudLab Profile
-You can use our CloudLab profile [ntu-cloud/vhive-ubuntu20][cloudlab-pf].
+You can use our CloudLab profile [ntu-cloud/vhive-ubuntu24][cloudlab-pf].
 
-It is recommended to use a base Ubuntu 20.04 image for each node and connect the nodes in a LAN.
+It is recommended to use a base Ubuntu 24.04 image for each node and connect the nodes in a LAN.
 
 #### B. Nodes to Rent
 We tested the following instructions by setting up a **2-node** cluster on Cloudlab, using all of the following SSD-equipped machines: `xl170` on Utah, `rs440` on Mass, `m400` on OneLab. `xl170` are normally less occupied than the other two, and users can consider other SSD-based machines too.
@@ -447,7 +447,7 @@ kn service delete --all
 
 [github-toc]: https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/
 [cloudlab]: https://www.cloudlab.us
-[cloudlab-pf]: https://www.cloudlab.us/p/ntu-cloud/vhive-ubuntu20
+[cloudlab-pf]: https://www.cloudlab.us/p/ntu-cloud/vhive-ubuntu24
 [cloudlab-hw]: https://docs.cloudlab.us/hardware.html
 [ext-abstract]: https://asplos-conference.org/abstracts/asplos21-paper212-extended_abstract.pdf
 [kn-benchmark]: https://github.com/vhive-serverless/vSwarm/blob/main/docs/adding_benchmarks.md


### PR DESCRIPTION
## Summary

Update the versions of Ubuntu in Github Runners due to Ubuntu 20.04 going deprecated.

## Implementation Notes :hammer_and_pick:

* Update version in workflow
* Update profile on CloudLab to newer version of Ubuntu

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
