### PR TITLE
Fix snapshot commit

### DIFF
--- a/.github/workflows/cri_tests.yml
+++ b/.github/workflows/cri_tests.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Run vHive CRI tests
         run: source /etc/profile && go clean -testcache && go test ./cri -v -race -cover
 
+      - name: Run sandbox specific tests
+        if: ${{ inputs.sandbox == 'firecracker' }}
+        run: source /etc/profile && go clean -testcache && go test ./cri/${{ inputs.sandbox }} -v -race -cover
+
       - name: Archive log artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Ensure snapshots are initialized and committed using the same revision identifier to allow successful commit and future reuse.

Refer to #1087 for more details.

## Implementation Notes :hammer_and_pick:

* Replaced the incorrect `fi.VmID` with `fi.Revision` in the call to `CommitSnapshot` on `orchCreateSnapshot`.
* Added test (`TestOrchCreateSnapshot`) to verify that the snapshot is correctly committed.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
