### PR TITLE
Migrates tests from self-hosted to github actions (ubuntu-24.04)

### DIFF
--- a/.github/workflows/cri_stock_containerd_test.yml
+++ b/.github/workflows/cri_stock_containerd_test.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   stock-containerd-test:
     name: Stock Containerd test
-    runs-on: [self-hosted, cri]
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Setup TMPDIR

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   integration-tests:
     name: Integration tests
-    runs-on: [self-hosted , integ]
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   integration-tests:
     name: Test all functions
-    runs-on: [self-hosted, nightly, integ]
+    runs-on: ubuntu-24.04
     steps:
     - name: Setup TMPDIR
       run: mkdir -p $TMPDIR
@@ -51,7 +51,7 @@ jobs:
 
   cri-tests:
     name: CRI tests (nightly)
-    runs-on: [self-hosted, cri]
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/skip_cri_tests.yml
+++ b/.github/workflows/skip_cri_tests.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       GITHUB_RUN_ID: ${{ github.run_id }}
       GITHUB_VHIVE_ARGS: "-dbg"
-    runs-on: ${{ fromJSON(format('["self-hosted", "{0}-cri"]', inputs.sandbox)) }}
+    runs-on: ubuntu-24.04
 
     steps:
       - run: 'echo "This check not required"'

--- a/.github/workflows/skip_integration_tests.yml
+++ b/.github/workflows/skip_integration_tests.yml
@@ -24,6 +24,6 @@ env:
 jobs:
   integration-tests:
     name: Integration tests
-    runs-on: [self-hosted , integ]
+    runs-on: ubuntu-24.04
     steps:
       - run: 'echo "This check not required"'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -119,7 +119,7 @@ jobs:
 
   firecracker-containerd-interface-test:
     name: "Unit tests: Firecracker-containerd interface"
-    runs-on: [self-hosted, integ]
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Move the  Github workflows test from self-hosted runners to github runners (plain github actions)

## Implementation Notes :hammer_and_pick:

* Put simply it is a simple sed  command (sed "s/self-hosted/ubuntu/" *.yml)

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

