### PR TITLE
Improve CI reliability

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -143,6 +143,9 @@ jobs:
         sudo apt update
         sudo apt install rsync -y
 
+    - name: Cleanup runner disk space
+      run: ./scripts/github_runner/gh-actions-disk-cleanup.sh
+
     - name: Build setup scripts
       run: pushd scripts && go build -o setup_tool && popd
 

--- a/ctriface/Makefile
+++ b/ctriface/Makefile
@@ -28,24 +28,23 @@ BENCHFILES:=bench_test.go iface.go orch_options.go orch.go
 # WITHLAZY:=-lazy
 WITHUPF:=
 WITHLAZY:=
-STARGZ:=-ss 'proxy'
-STARGZ_IMAGE:=-img 'ghcr.io/vhive-serverless/helloworld:var_workload-esgz'
+STARGZ:=-ss 'proxy' -img 'ghcr.io/vhive-serverless/helloworld:var_workload-esgz'
 DOCKER_CREDENTIALS:=-dockerCredentials '{"docker-credentials":{"ghcr.io":{"username":"","password":""}}}'
 GOBENCH:=-v -timeout 1500s
 CTRDLOGDIR:=/tmp/ctrd-logs
 
 test:
 	./../scripts/clean_fcctr.sh
-	sudo env "PATH=$(PATH)" /usr/local/bin/http-address-resolver &
-	sudo env "PATH=$(PATH)" /bin/bash -c 'while true; do /usr/local/bin/demux-snapshotter; done' &
-	sudo mkdir -m777 -p $(CTRDLOGDIR) && sudo env "PATH=$(PATH)" /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/ctriface_log.out 2>$(CTRDLOGDIR)/ctriface_log.err &
-	sudo env "PATH=$(PATH)" go test $(EXTRATESTFILES) $(EXTRAGOARGS) -args $(STARGZ) $(DOCKER_CREDENTIALS) $(STARGZ_IMAGE)
-	./../scripts/clean_fcctr.sh
 	sudo mkdir -m777 -p $(CTRDLOGDIR) && sudo env "PATH=$(PATH)" /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/ctriface_log.out 2>$(CTRDLOGDIR)/ctriface_log.err &
 	sudo env "PATH=$(PATH)" go test $(EXTRATESTFILES) $(EXTRAGOARGS)
 	./../scripts/clean_fcctr.sh
 	sudo mkdir -m777 -p $(CTRDLOGDIR) && sudo env "PATH=$(PATH)" /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/ctriface_log.out 2>$(CTRDLOGDIR)/ctriface_log.err &
 	sudo env "PATH=$(PATH)" go test $(EXTRATESTFILES) $(EXTRAGOARGS) -args $(WITHUPF)
+	./../scripts/clean_fcctr.sh
+	sudo env "PATH=$(PATH)" /usr/local/bin/http-address-resolver &
+	sudo env "PATH=$(PATH)" /bin/bash -c 'while true; do /usr/local/bin/demux-snapshotter; done' &
+	sudo mkdir -m777 -p $(CTRDLOGDIR) && sudo env "PATH=$(PATH)" /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/ctriface_log.out 2>$(CTRDLOGDIR)/ctriface_log.err &
+	sudo env "PATH=$(PATH)" go test $(EXTRATESTFILES) $(EXTRAGOARGS) -args $(STARGZ) $(DOCKER_CREDENTIALS)
 	./../scripts/clean_fcctr.sh
 
 test-man:

--- a/scripts/github_runner/gh-actions-disk-cleanup.sh
+++ b/scripts/github_runner/gh-actions-disk-cleanup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# cleanup-runner-space.sh
+# Frees up disk space on GitHub Actions runners by removing large preinstalled packages and directories.
+
+set -euo pipefail
+
+echo "=============================================================================="
+echo "Freeing up disk space on GitHub Actions runner 🧹"
+echo "=============================================================================="
+
+echo ""
+echo "Initial disk usage:"
+df -h
+
+echo ""
+echo "Removing large unused packages..."
+
+# Remove specific packages by pattern (ignore errors gracefully)
+remove_patterns=(
+  '^ghc-8.*'
+  '^dotnet-.*'
+  '^llvm-.*'
+  'php.*'
+)
+
+for pattern in "${remove_patterns[@]}"; do
+  echo "  - Removing packages matching: $pattern"
+  sudo apt-get remove -y "$pattern" || true
+done
+
+# Remove specific large individual packages
+large_packages=(
+  azure-cli
+  google-cloud-sdk
+  hhvm
+  google-chrome-stable
+  firefox
+  powershell
+  mono-devel
+)
+
+echo "  - Removing known large packages..."
+sudo apt-get remove -y "${large_packages[@]}" || true
+
+echo ""
+echo "Cleaning up unused dependencies and package cache..."
+sudo apt-get autoremove -y
+sudo apt-get clean
+
+echo ""
+echo "Removing large directories..."
+
+large_dirs=(
+  /usr/share/dotnet/
+  /opt/ghc
+  /usr/local/lib/android
+)
+
+for dir in "${large_dirs[@]}"; do
+  echo "  - Deleting: $dir"
+  sudo rm -rf "$dir"
+done
+
+echo ""
+echo "✅ Disk usage after cleanup:"
+df -h


### PR DESCRIPTION
## Summary

Some tests were failing due to insufficient disk space on the GitHub Actions runner. This commit adds a pre-test cleanup step that removes large, unused packages and SDKs to reclaim space and improve CI reliability.

This issue was discussed in this GH community [#25678](https://github.com/orgs/community/discussions/25678).

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A
