### PR TITLE
Adds lfs:false to the tests that do not require it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       with:
         # to add commit DCO checks later
         fetch-depth: 21
+        lfs: false
 
     - name: Set up Go ${{ matrix.go }}
       uses: actions/setup-go@v5

--- a/.github/workflows/build_setup.yml
+++ b/.github/workflows/build_setup.yml
@@ -25,6 +25,8 @@ jobs:
 
         - name: Check out the code
           uses: actions/checkout@v4
+          with:
+            lfs: false
 
         - name: Set up Go version in go.mod file
           uses: actions/setup-go@v5
@@ -39,4 +41,3 @@ jobs:
         
         - name: Show scripts help info
           run: ./scripts/setup_tool -h
-        

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        lfs: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
+      with:
+        lfs: false
     - uses: rojopolis/spellcheck-github-actions@0.48.0
       name: Spellcheck
       with:
@@ -22,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          lfs: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -40,6 +43,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: false
       - uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'


### PR DESCRIPTION
## Summary

This PR disables Git Large File Storage (LFS) checkout in GitHub Actions workflows for jobs and steps that do not require LFS, optimizing workflow performance and reducing unnecessary resource usage.

## Implementation Notes :hammer_and_pick:

- Added `lfs: false` to the `actions/checkout` steps in the following workflows:
  - `.github/workflows/build.yml`
  - `.github/workflows/build_setup.yml`
  - `.github/workflows/codeql-analysis.yml`
  - `.github/workflows/linters.yml`
- This change ensures that LFS files are not fetched for jobs that do not need them, which can speed up CI runs and avoid hitting LFS bandwidth/storage limits.
- No other logic or build/test steps were modified.
- Reviewers should verify that none of the affected jobs require LFS-managed files for their operation.

## External Dependencies :four_leaf_clover:

None.

## Breaking API Changes :warning:

None.
