### PR TITLE
Convert stargz tests to manual tests

### DIFF
--- a/ctriface/Makefile
+++ b/ctriface/Makefile
@@ -41,11 +41,6 @@ test:
 	sudo mkdir -m777 -p $(CTRDLOGDIR) && sudo env "PATH=$(PATH)" /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/ctriface_log.out 2>$(CTRDLOGDIR)/ctriface_log.err &
 	sudo env "PATH=$(PATH)" go test $(EXTRATESTFILES) $(EXTRAGOARGS) -args $(WITHUPF)
 	./../scripts/clean_fcctr.sh
-	sudo env "PATH=$(PATH)" /usr/local/bin/http-address-resolver &
-	sudo env "PATH=$(PATH)" /bin/bash -c 'while true; do /usr/local/bin/demux-snapshotter; done' &
-	sudo mkdir -m777 -p $(CTRDLOGDIR) && sudo env "PATH=$(PATH)" /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/ctriface_log.out 2>$(CTRDLOGDIR)/ctriface_log.err &
-	sudo env "PATH=$(PATH)" go test $(EXTRATESTFILES) $(EXTRAGOARGS) -args $(STARGZ) $(DOCKER_CREDENTIALS)
-	./../scripts/clean_fcctr.sh
 
 test-man:
 	./../scripts/clean_fcctr.sh
@@ -66,6 +61,11 @@ test-man:
 	sudo mkdir -m777 -p $(CTRDLOGDIR) && sudo env "PATH=$(PATH)" /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/ctriface_log_remote_snap_load_man_travis.out 2>$(CTRDLOGDIR)/ctriface_log_remote_snap_load_man_travis.err &
 	# Loads the remote snapshot.
 	sudo env "PATH=$(PATH)" go test $(EXTRAGOARGS) -run TestRemoteSnapLoad
+	./../scripts/clean_fcctr.sh
+	sudo env "PATH=$(PATH)" /usr/local/bin/http-address-resolver &
+	sudo env "PATH=$(PATH)" /bin/bash -c 'while true; do /usr/local/bin/demux-snapshotter; done' &
+	sudo mkdir -m777 -p $(CTRDLOGDIR) && sudo env "PATH=$(PATH)" /usr/local/bin/firecracker-containerd --config /etc/firecracker-containerd/config.toml 1>$(CTRDLOGDIR)/ctriface_log.out 2>$(CTRDLOGDIR)/ctriface_log.err &
+	sudo env "PATH=$(PATH)" go test $(EXTRAGOARGS) -run TestSnapLoad -args $(STARGZ) $(DOCKER_CREDENTIALS)
 	./../scripts/clean_fcctr.sh
 
 test-skip:

--- a/ctriface/manual_cleanup_test.go
+++ b/ctriface/manual_cleanup_test.go
@@ -60,23 +60,24 @@ func TestSnapLoad(t *testing.T) {
 	defer cancel()
 
 	orch := NewOrchestrator(
-		"devmapper",
+		*snapshotter,
 		"",
 		WithTestModeOn(true),
 		WithUPF(*isUPFEnabled),
 		WithLazyMode(*isLazyMode),
+		WithDockerCredentials(*dockerCredentials),
 	)
 
 	vmID := "1"
 	revision := "myrev-1"
 
-	_, _, err := orch.StartVM(ctx, vmID, testImageName)
+	_, _, err := orch.StartVM(ctx, vmID, *testImage)
 	require.NoError(t, err, "Failed to start VM")
 
 	err = orch.PauseVM(ctx, vmID)
 	require.NoError(t, err, "Failed to pause VM")
 
-	snap := snapshotting.NewSnapshot(revision, "/fccd/snapshots", testImageName)
+	snap := snapshotting.NewSnapshot(revision, "/fccd/snapshots", *testImage)
 	err = snap.CreateSnapDir()
 	require.NoError(t, err, "Failed to create snapshots directory")
 
@@ -121,23 +122,24 @@ func TestSnapLoadMultiple(t *testing.T) {
 	defer cancel()
 
 	orch := NewOrchestrator(
-		"devmapper",
+		*snapshotter,
 		"",
 		WithTestModeOn(true),
 		WithUPF(*isUPFEnabled),
 		WithLazyMode(*isLazyMode),
+		WithDockerCredentials(*dockerCredentials),
 	)
 
 	vmID := "3"
 	revision := "myrev-3"
 
-	_, _, err := orch.StartVM(ctx, vmID, testImageName)
+	_, _, err := orch.StartVM(ctx, vmID, *testImage)
 	require.NoError(t, err, "Failed to start VM")
 
 	err = orch.PauseVM(ctx, vmID)
 	require.NoError(t, err, "Failed to pause VM")
 
-	snap := snapshotting.NewSnapshot(revision, "/fccd/snapshots", testImageName)
+	snap := snapshotting.NewSnapshot(revision, "/fccd/snapshots", *testImage)
 	err = snap.CreateSnapDir()
 	require.NoError(t, err, "Failed to create snapshots directory")
 
@@ -196,15 +198,16 @@ func TestParallelSnapLoad(t *testing.T) {
 	vmIDBase := 6
 
 	orch := NewOrchestrator(
-		"devmapper",
+		*snapshotter,
 		"",
 		WithTestModeOn(true),
 		WithUPF(*isUPFEnabled),
 		WithLazyMode(*isLazyMode),
+		WithDockerCredentials(*dockerCredentials),
 	)
 
 	// Pull image
-	_, err := orch.getImage(ctx, testImageName)
+	_, err := orch.getImage(ctx, *testImage)
 	require.NoError(t, err, "Failed to pull image "+testImageName)
 
 	var vmGroup sync.WaitGroup
@@ -215,13 +218,13 @@ func TestParallelSnapLoad(t *testing.T) {
 			vmID := fmt.Sprintf("%d", i+vmIDBase)
 			revision := fmt.Sprintf("myrev-%d", i+vmIDBase)
 
-			_, _, err := orch.StartVM(ctx, vmID, testImageName)
+			_, _, err := orch.StartVM(ctx, vmID, *testImage)
 			require.NoError(t, err, "Failed to start VM, "+vmID)
 
 			err = orch.PauseVM(ctx, vmID)
 			require.NoError(t, err, "Failed to pause VM, "+vmID)
 
-			snap := snapshotting.NewSnapshot(revision, "/fccd/snapshots", testImageName)
+			snap := snapshotting.NewSnapshot(revision, "/fccd/snapshots", *testImage)
 			err = snap.CreateSnapDir()
 			require.NoError(t, err, "Failed to create snapshots directory")
 
@@ -274,15 +277,16 @@ func TestParallelPhasedSnapLoad(t *testing.T) {
 	vmIDBase := 16
 
 	orch := NewOrchestrator(
-		"devmapper",
+		*snapshotter,
 		"",
 		WithTestModeOn(true),
 		WithUPF(*isUPFEnabled),
 		WithLazyMode(*isLazyMode),
+		WithDockerCredentials(*dockerCredentials),
 	)
 
 	// Pull image
-	_, err := orch.getImage(ctx, testImageName)
+	_, err := orch.getImage(ctx, *testImage)
 	require.NoError(t, err, "Failed to pull image "+testImageName)
 
 	{
@@ -292,7 +296,7 @@ func TestParallelPhasedSnapLoad(t *testing.T) {
 			go func(i int) {
 				defer vmGroup.Done()
 				vmID := fmt.Sprintf("%d", i+vmIDBase)
-				_, _, err := orch.StartVM(ctx, vmID, testImageName)
+				_, _, err := orch.StartVM(ctx, vmID, *testImage)
 				require.NoError(t, err, "Failed to start VM, "+vmID)
 			}(i)
 		}
@@ -321,7 +325,7 @@ func TestParallelPhasedSnapLoad(t *testing.T) {
 				defer vmGroup.Done()
 				vmID := fmt.Sprintf("%d", i+vmIDBase)
 				revision := fmt.Sprintf("myrev-%d", i+vmIDBase)
-				snap := snapshotting.NewSnapshot(revision, "/fccd/snapshots", testImageName)
+				snap := snapshotting.NewSnapshot(revision, "/fccd/snapshots", *testImage)
 				err = snap.CreateSnapDir()
 				require.NoError(t, err, "Failed to create snapshots directory")
 
@@ -356,7 +360,7 @@ func TestParallelPhasedSnapLoad(t *testing.T) {
 			go func(i int) {
 				defer vmGroup.Done()
 				vmID := fmt.Sprintf("%d", i+vmIDBase)
-				snap := snapshotting.NewSnapshot(vmID, "/fccd/snapshots", testImageName)
+				snap := snapshotting.NewSnapshot(vmID, "/fccd/snapshots", *testImage)
 				vmIDInt, _ := strconv.Atoi(vmID)
 				vmID = strconv.Itoa(vmIDInt + 1)
 				_, _, err := orch.LoadSnapshot(ctx, vmID, snap)
@@ -420,20 +424,21 @@ func TestRemoteSnapCreate(t *testing.T) {
 	require.NoError(t, err, "Failed to create remote snapshots directory")
 
 	orch := NewOrchestrator(
-		"devmapper",
+		*snapshotter,
 		"",
 		WithTestModeOn(true),
 		WithUPF(*isUPFEnabled),
 		WithLazyMode(*isLazyMode),
+		WithDockerCredentials(*dockerCredentials),
 	)
 
-	_, _, err = orch.StartVM(ctx, vmID, testImageName)
+	_, _, err = orch.StartVM(ctx, vmID, *testImage)
 	require.NoError(t, err, "Failed to start VM")
 
 	err = orch.PauseVM(ctx, vmID)
 	require.NoError(t, err, "Failed to pause VM")
 
-	snap := snapshotting.NewSnapshot(revision, remoteSnapshotsDir, testImageName)
+	snap := snapshotting.NewSnapshot(revision, remoteSnapshotsDir, *testImage)
 	_ = snap.Cleanup()
 	err = snap.CreateSnapDir()
 	require.NoError(t, err, "Failed to create remote snapshots directory")
@@ -473,14 +478,15 @@ func TestRemoteSnapLoad(t *testing.T) {
 	require.NoError(t, err, "Failed to stat remote snapshots directory")
 
 	orch := NewOrchestrator(
-		"devmapper",
+		*snapshotter,
 		"",
 		WithTestModeOn(true),
 		WithUPF(*isUPFEnabled),
 		WithLazyMode(*isLazyMode),
+		WithDockerCredentials(*dockerCredentials),
 	)
 
-	snap := snapshotting.NewSnapshot(revision, remoteSnapshotsDir, testImageName)
+	snap := snapshotting.NewSnapshot(revision, remoteSnapshotsDir, *testImage)
 
 	_, _, err = orch.LoadSnapshot(ctx, vmID, snap)
 	require.NoError(t, err, "Failed to load remote snapshot of VM")

--- a/scripts/stargz/setup_stargz.go
+++ b/scripts/stargz/setup_stargz.go
@@ -33,7 +33,7 @@ func SetupStargz(sandbox string) error {
 	if sandbox == "firecracker" {
 		_, err = utils.ExecVHiveBashScript("scripts/stargz/setup_demux_snapshotter.sh")
 
-		bashCmd := `sudo sysctl --quiet -w net.ipv4.conf.all.forwarding=1 && ` + 
+		bashCmd := `sudo sysctl --quiet -w net.ipv4.conf.all.forwarding=1 && ` +
 			`sudo sysctl --quiet -w net.ipv4.ip_forward=1 && ` +
 			`sudo sysctl --quiet --system`
 


### PR DESCRIPTION
## Summary

The unit tests for the Firecracker-containerd interface using the stargz snapshotter were too flaky. It's better to run them in a more controlled way. By running them manually, we can clean and restart Firecracker, making the tests less flaky.

## Implementation Notes :hammer_and_pick:

- Changed tests in `ctriface/manual_cleanup_test.go` to allow using stargz snapshotter, by using the same parameters used in `ctriface/iface_test.go`.

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

N/A
