### PR TITLE
Add kernel message on integration test failure

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -66,6 +66,12 @@ jobs:
     - name: Run vHive end-to-end tests
       run: make ${{ matrix.test-name }}
 
+    - name: Kernel message
+      if: failure()
+      run: |
+        sudo lsmod
+        sudo dmesg -T -f kern
+
     - name: Archive log artifacts
       if: ${{ always() }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

In this [PR](https://github.com/vhive-serverless/vHive/pull/1126), running separate instances of firecracker-containerd also produces the same flake. Adding kernel message logging on failure might help us debug the cause.

Ref: https://github.com/vhive-serverless/vHive/issues/1113

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*
