### PR TITLE
Migrate CI workflow to github runner (CRI tests)

### DIFF
--- a/.github/workflows/cri_tests.yml
+++ b/.github/workflows/cri_tests.yml
@@ -13,16 +13,24 @@ env:
 jobs:
   cri-tests:
     name: CRI tests
+    # Skip gVisor tests (requires cgroups v1, Ubuntu 24.04 uses cgroups v2)
+    if: ${{ inputs.sandbox != 'gvisor' }}
     env:
       GITHUB_RUN_ID: ${{ github.run_id }}
       GITHUB_VHIVE_ARGS: "-dbg"
-    runs-on: ${{ fromJSON(format('["self-hosted", "{0}-cri"]', inputs.sandbox)) }}
+    runs-on: ubuntu-24.04
 
     steps:
-      - name: Host Info
+      - name: Free up disk space
         run: |
-          echo $HOSTNAME
-          echo $GITHUB_RUN_ID
+          sudo rm -rf /usr/share/dotnet \
+                      /opt/ghc \
+                      /usr/local/share/boost \
+                      "$AGENT_TOOLSDIRECTORY" \
+                      /usr/local/lib/android \
+                      /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+          docker system prune -af --volumes
 
       - name: Checkout code
         uses: actions/checkout@v5
@@ -39,13 +47,15 @@ jobs:
         run: |
           sudo apt update
           sudo apt install rsync -y
-
       - name: Build setup scripts
         run: pushd scripts && go build -o setup_tool && popd
 
-      - name: Setup vHive CRI test environment
-        run: ./scripts/github_runner/setup_cri_test_env.sh ${{ inputs.sandbox }}
+      - name: Setup system
+        run: ./scripts/setup_tool setup_node ${{ inputs.sandbox }}
 
+      - name: Setup CRI test environment
+        run: ./scripts/github_runner/setup_cri_test_env.sh ${{ inputs.sandbox }}
+             
       - name: Run vHive CRI tests
         run: source /etc/profile && go clean -testcache && go test ./cri -v -race -cover
 
@@ -62,7 +72,3 @@ jobs:
             /tmp/ctrd-logs/${{ github.run_id }}
             ${{ github.workspace }}/*.log
             ${{ github.workspace }}/scripts/github_runner/*.log
-
-      - name: Cleaning
-        if: ${{ always() }}
-        run: ./scripts/github_runner/clean_cri_runner.sh ${{ inputs.sandbox }}

--- a/scripts/setup/setup.go
+++ b/scripts/setup/setup.go
@@ -40,6 +40,12 @@ func SetupFirecrackerContainerd() error {
 		return err
 	}
 
+	// Create snapshot base directory
+	_, err = utils.ExecShellCmd("sudo mkdir -p /fccd && sudo chmod 777 /fccd")
+	if err != nil {
+		return err
+	}
+
 	// Pull LFS in vHive
 	utils.WaitPrintf("Pulling LFS in vHive")
 	if err := utils.CheckVHiveRepo(); !utils.CheckErrorWithMsg(err, "Failed to pull LFS in vHive!\n") {


### PR DESCRIPTION
## Summary

Migration of cri tests from self-hosted runner to github runner.
Reopen of PR #1171. Refer for previous comments. (removed profile tests migration)

## Implementation Notes :hammer_and_pick:

Modified CI workflow configuration for CRI tests only.
Gvisor CRI tests disabled on github hosted runner workflow.
--> gvisor-containerd binary requires cgroupv1, while ubuntu 24.04 defaults to cgroupv2. Github hosted runners do not grant the necessary permissions to switch from cgroupv2 to cgroupv1

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

N/A