### PR TITLE
Retrieve DNS from k8s only on orchestrator creation

### DIFF
--- a/ctriface/iface.go
+++ b/ctriface/iface.go
@@ -26,9 +26,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -344,24 +342,6 @@ func (o *Orchestrator) getImage(ctx context.Context, imageName string) (*contain
 	return o.imageManager.GetImage(ctx, imageName, o.snapshotter != "proxy")
 }
 
-func getK8sDNS() []string {
-	//using googleDNS as a backup
-	dnsIPs := []string{"8.8.8.8"}
-	//get k8s DNS clusterIP
-	cmd := exec.Command(
-		"kubectl", "get", "service", "-n", "kube-system", "kube-dns", "-o=custom-columns=:.spec.clusterIP", "--no-headers",
-	)
-	stdoutStderr, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Warnf("Failed to Fetch k8s dns clusterIP %v\n%s\n", err, stdoutStderr)
-		log.Warnf("Using google dns %s\n", dnsIPs[0])
-	} else {
-		//adding k8s DNS clusterIP to the list
-		dnsIPs = []string{strings.TrimSpace(string(stdoutStderr)), dnsIPs[0]}
-	}
-	return dnsIPs
-}
-
 func (o *Orchestrator) getVMConfig(vm *misc.VM) *proto.CreateVMRequest {
 	kernelArgs := "ro noapic reboot=k panic=1 acpi=off pci=off nomodules systemd.log_color=false systemd.journald.forward_to_console systemd.unit=firecracker.target init=/sbin/overlay-init tsc=reliable quiet ipv6.disable=1 console=ttyS0"
 
@@ -381,7 +361,7 @@ func (o *Orchestrator) getVMConfig(vm *misc.VM) *proto.CreateVMRequest {
 				IPConfig: &proto.IPConfiguration{
 					PrimaryAddr: vm.GetPrimaryAddr(),
 					GatewayAddr: vm.GetGatewayAddr(),
-					Nameservers: getK8sDNS(),
+					Nameservers: o.dns,
 				},
 			},
 		}},

--- a/ctriface/orch.go
+++ b/ctriface/orch.go
@@ -25,6 +25,7 @@ package ctriface
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -104,6 +105,7 @@ type Orchestrator struct {
 	snapshotsDir     string
 	isMetricsMode    bool
 	netPoolSize      int
+	dns              []string
 
 	vethPrefix  string
 	clonePrefix string
@@ -124,6 +126,8 @@ func NewOrchestrator(snapshotter, hostIface string, opts ...OrchestratorOption) 
 	o.netPoolSize = 10
 	o.vethPrefix = "172.17"
 	o.clonePrefix = "172.18"
+
+	o.dns = getK8sDNS()
 
 	for _, opt := range opts {
 		opt(o)
@@ -166,6 +170,24 @@ func NewOrchestrator(snapshotter, hostIface string, opts ...OrchestratorOption) 
 	o.imageManager = image.NewImageManager(o.client, o.snapshotter)
 
 	return o
+}
+
+func getK8sDNS() []string {
+	//using googleDNS as a backup
+	dnsIPs := []string{"8.8.8.8"}
+	//get k8s DNS clusterIP
+	cmd := exec.Command(
+		"kubectl", "get", "service", "-n", "kube-system", "kube-dns", "-o=custom-columns=:.spec.clusterIP", "--no-headers",
+	)
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Warnf("Failed to Fetch k8s dns clusterIP %v\n%s\n", err, stdoutStderr)
+		log.Warnf("Using google dns %s\n", dnsIPs[0])
+	} else {
+		//adding k8s DNS clusterIP to the list
+		dnsIPs = []string{strings.TrimSpace(string(stdoutStderr)), dnsIPs[0]}
+	}
+	return dnsIPs
 }
 
 func (o *Orchestrator) setupCloseHandler() {


### PR DESCRIPTION
## Summary

Move k8s DNS checks to orchestrator creation from each instance creation. The result is -50ms on instance creations.

## Implementation Notes :hammer_and_pick:

* Save the DNS servers during the orchestrator creation.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A